### PR TITLE
Disable mesh rendering for minimap

### DIFF
--- a/hooks/MinimapMesh.cpp
+++ b/hooks/MinimapMesh.cpp
@@ -1,0 +1,20 @@
+//HOOK selectionPriority ROffset = 0x3D1AE9
+
+#include <stdlib.h>
+#include "../preprocessor/define.h"
+#include "../preprocessor/macro.h"
+
+__asm__
+(
+    ".equ by_pass_address,"QU(minimapMesh)"-0x007D1AE9 \n"
+);
+
+__asm__ volatile
+(
+    "jmp . + by_pass_address \n"
+    "nop \n"
+    "nop \n"
+    "nop \n"
+    "nop \n"
+    ".align 128, 0x0 \n"
+);

--- a/sections/MinimapMesh.cpp
+++ b/sections/MinimapMesh.cpp
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+
+//Adding ability to disable mesh renderer for minimap
+//if DefaultMiniLOD = 0 (there is a console command for it) then Moho::Cartographic::RenderMeshes function call will be skipped
+//this allows to skip an enormous amount of useless computations, as minimap works similar to main camera
+//and as it's mainly zoomed out, there are thousands of objects that are always in view
+//and this in turn causes mesh renderer to do thousands of useless LOD calculations per frame
+
+void minimapMesh()
+{
+	__asm__
+	(
+        "cmp dword ptr [0x00F57A88], 0x0 \n"
+        "jne MeshRenderON \n"
+        "jmp 0x007D1B02 \n"
+        "MeshRenderON: \n"
+        "push ebp \n"
+        "push ecx \n"
+        "mov ecx, dword ptr [esp+0xA8] \n"
+        "jmp 0x007D1AF2 \n"
+	);
+}


### PR DESCRIPTION
Console command: "cam_DefaultMiniLOD 0" now completely disable mesh renderer for minimap