### PR TITLE
change GiveNukeSiloAmmo()

### DIFF
--- a/hooks/GiveNukeSiloAmmo.cpp
+++ b/hooks/GiveNukeSiloAmmo.cpp
@@ -1,0 +1,10 @@
+#include "../define.h"
+asm(
+  //HOOK SiloAmmoCheckArgs
+  ".section h0; .set h0,0x6CED77;"
+  "JMP "QU(SiloAmmoCheckArgs)";"
+  
+  //HOOK SiloAmmoSetBlocks
+  ".section h1; .set h1,0x6CEDF1;"
+  "JMP "QU(SiloAmmoSetBlocks)";"
+);

--- a/section/GiveNukeSiloAmmo.cpp
+++ b/section/GiveNukeSiloAmmo.cpp
@@ -1,0 +1,53 @@
+char Blocks[1];
+
+// Change unit:GiveNukeSiloAmmo(int) behaviour to be able to set work progress manually
+// this way we can save half done missiles after unit transfer (works with SMLs and SMDs)
+//
+// Now when passing any second argumnent (just use True), the function will change the number of finished blocks instead of adding the missile to silo
+// As you know missile launchers build missiles in different way compare to normal factories (see Moho::CAiSiloBuildImpl::SiloTick)
+// every job is divided into "blocks". The number of blocks is calculated using this formula:
+//
+// blocks = missileBuildTime / launcherBuildPower * 10
+//
+// for standard SML there will be 450000/1500*10 = 3000 blocks
+//
+// so 3000 blocks is 100%. Then if you need to set, let say, 35% just send 1050 (integer) as first argument and True\False\whatever as second. Example:
+// unit:GiveNukeSiloAmmo(1050, True)
+
+void SiloAmmoCheckArgs()
+{
+    asm(
+        "mov %[Blocks], 0;"
+        "je 0x6CED8B;"
+        "cmp eax, 3;" //change blocks if third arg exists
+        "jne 0x6CED7C;"
+        "mov %[Blocks], 1;"
+        "jmp 0x6CED8B;"
+        :
+        : [Blocks] "m" (Blocks)
+        :
+    );
+}
+
+void SiloAmmoSetBlocks()
+{
+    asm(
+        "cmp %[Blocks], 0;"
+        "je Finish;"
+        "add ebx, 72;"
+        "mov dword ptr [ebx], eax;" //here we set the number of blocks. This value is used by Moho::CAiSiloBuildImpl::SiloTick for calculations
+        "sub ebx, 72;"
+        "mov eax, 0;"
+        
+        
+        //default code
+        "Finish:;"
+        "mov edx, dword ptr [edi];"
+        "push eax;"
+        "push 1;"
+        "jmp 0x6CEDF6"
+        :
+        : [Blocks] "m" (Blocks)
+        :
+    );
+}


### PR DESCRIPTION
Change unit:GiveNukeSiloAmmo(int) behaviour to be able to set work progress manually
this way we can save half done missiles after unit transfer (works with SMLs and SMDs)

Now when passing any second argumnent (just use True), the function will change the number of finished blocks instead of adding the missile to silo. As you know missile launchers build missiles in different way compare to normal factories (see Moho::CAiSiloBuildImpl::SiloTick)
every job is divided into "blocks". The number of blocks is calculated using this formula:

`blocks = missileBuildTime / launcherBuildPower * 10`

for standard SML there will be `450000/1500*10 = 3000` blocks

so 3000 blocks is 100%. Then if you need to set, let say, 35% just send 1050 (integer) as first argument and True\False\whatever as second. Example: `unit:GiveNukeSiloAmmo(1050, True)`

exe for testing: https://mega.nz/file/5RJUmBKY#wnwH6LcTi5S90eRyXDrawezGLtbQf1t2XZMNAOAiH9k