### PR TITLE
simGetCommandQueue

### DIFF
--- a/hooks/SimGetCommandQueue.cpp
+++ b/hooks/SimGetCommandQueue.cpp
@@ -1,0 +1,9 @@
+#include "../define.h"
+asm(
+  ".section h0; .set h0,0x6CE3B2;"
+  "jmp "QU(SimGetCommandQueue)";"
+  
+  ".section h1; .set h1,0x6CE3B7;"
+  "call "QU(SimGetCommandQueueCpp)";"
+  "add esp, 0x10;"
+);

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -646,8 +646,12 @@ struct CUnitCommand
 	string unk5;
 	// at 0x98
 	uint32_t Order;
+    // at 0xA0
+    uint32_t targetId; //entityId = (targetId & 1FFFFF)
 	// at 0xA4
 	Vector4f Pos1;
+    // at 0x120
+    //Unit Target; // -0xC
 	// at 0x128
 	Vector3f Pos2;
 	// at 0x160

--- a/section/simGetCommandQueue.cpp
+++ b/section/simGetCommandQueue.cpp
@@ -1,5 +1,7 @@
 #include "include/moho.h"
 #include "include/LuaAPI.h"
+#include <stdint.h>
+#include <stdio.h>
 
 int commandType;
 int targetId;
@@ -7,6 +9,7 @@ char* bpId;
 float x;
 float y;
 float z;
+char tgtIdAsString[11];
 
 LuaState* LuaS;
 LuaObject* O;
@@ -23,7 +26,19 @@ void SimGetCommandQueueCpp()
     
     if (targetId != -1)
     {
-        CLuaObject::SetInteger(&SubTable, "targetId", targetId);
+        int i = 0;
+        int i2 = 0;
+        char temp[10];
+        do {
+            temp[i++] = '0' + (targetId % 10);
+            targetId /= 10;
+            } while (targetId > 0);
+        
+        while(i > 0)
+            tgtIdAsString[i2++] = temp[--i];
+        tgtIdAsString[i2] = '\0';
+
+        CLuaObject::SetString(&SubTable, "targetId", tgtIdAsString);
     }
     
     CLuaObject::SetString(&SubTable, "blueprintId", bpId);

--- a/section/simGetCommandQueue.cpp
+++ b/section/simGetCommandQueue.cpp
@@ -1,0 +1,130 @@
+#include "include/moho.h"
+#include "include/LuaAPI.h"
+
+int commandType;
+int targetId;
+char* bpId;
+float x;
+float y;
+float z;
+
+LuaState* LuaS;
+LuaObject* O;
+LuaStackObject* S;
+LuaObject SubTable;
+
+void SimGetCommandQueueCpp()
+{
+    CLuaObject::AssignNewTable(&SubTable, LuaS, 0, 0);
+    CLuaObject::SetNumber(&SubTable, "commandType", commandType);
+    CLuaObject::SetNumber(&SubTable, "x", x);
+    CLuaObject::SetNumber(&SubTable, "y", y);
+    CLuaObject::SetNumber(&SubTable, "z", z);
+    
+    if (targetId != -1)
+    {
+        CLuaObject::SetInteger(&SubTable, "targetId", targetId);
+    }
+    
+    CLuaObject::SetString(&SubTable, "blueprintId", bpId);
+    CLuaObject::Insert(O, SubTable);
+    CLuaObject::DLuaObject(&SubTable);
+}
+
+void SimGetCommandQueue()
+{
+	asm(
+        "mov %[LuaS], ebx;"         //LuaState
+        "lea ebx, [esp+0x20];"
+        "mov %[O], ebx;"            //Main table
+        "lea ebx, [esp+0x18];"
+        "mov %[S], ebx;"            //Stack
+        "push 0;"
+        "push 0;"
+        "push 0;"
+        "push 0;"
+        "lea ebx, [esp];"
+        "mov %[SubTable], ebx;"     //SubTable
+        "mov ebx, %[LuaS];"
+        
+        
+        "push edx;"
+        "push eax;"
+        "mov eax, [esi];"
+        "mov edx, [eax+0x94];"
+        "mov %[commandType], edx;"  //commandType
+
+        "mov edx, [eax+0xA0];"
+        "mov %[x], edx;"            //X
+        
+        "mov edx, [eax+0xA4];"
+        "mov %[y], edx;"            //Y
+        
+        "mov edx, [eax+0xA8];"      
+        "mov %[z], edx;"            //Z
+        
+        "mov %[targetId], -1;"
+        "mov edx, [eax+0x9C];"
+        "cmp edx, 0xF0000000;"
+        "je Blueprint;"
+        "mov %[targetId], edx;"     //targetId  
+        
+        "Blueprint:;"
+        "mov %[bpId], 0x0;"
+        "mov edx, [eax+0x5C];"
+        "cmp edx, 0x0;"
+        "je End;"
+        "add edx, 0xC;"
+        "mov %[bpId], edx;"         //blueprintId
+        
+        "End:;"
+        "pop eax;"
+        "pop edx;"
+        "jmp 0x6CE3B7;"
+        :
+        : [commandType] "m" (commandType), [targetId] "m" (targetId), [bpId] "m" (bpId), [x] "m" (x), [y] "m" (y), [z] "m" (z), [SubTable] "m" (SubTable), [LuaS] "m" (LuaS), [O] "m" (O), [S] "m" (S)
+        :
+	);
+}
+
+/* Commands
+1 = Stop
+2 = Move
+3 = Dive
+4 = FormMove
+5 = BuildSiloTactical
+6 = BuildSiloNuke
+7 = BuildFactory
+8 = BuildMobile
+9 = BuildAssist
+10 = Attack
+11 = FormAttack
+12 = Nuke
+13 = Tactical
+14 = Teleport
+15 = Guard
+16 = Patrol
+17 = Ferry
+18 = FormPatrol
+19 = Reclaim
+20 = Repair
+21 = Capture
+22 = TransportLoadUnits
+23 = TransportReverseLoadUnits
+24 = TransportUnloadUnits
+25 = TransportUnloadSpecificUnits
+26 = DetachFromTransport
+27 = Upgrade
+28 = Script
+29 = AssistCommander
+30 = KillSelf
+31 = DestroySelf
+32 = Sacrifice
+33 = Pause
+34 = OverCharge
+35 = AggressiveMove
+36 = FormAggressiveMove
+37 = AssistMove
+38 = SpecialAction
+39 = Dock
+*/


### PR DESCRIPTION
Trying to fill GetCommand with actual info. Added commandID (see commit for ids translation) and x,y,z position. What we need now is target id (entityId). I've found a reference to current target in command object, but Idk what kind of structure is it. You can see entity postition there in floats and some other stuff, but for now idk where to find entityID. I'll try to look at it when I have time, but if someone want to help - you are welcome.

*add
Thx to KionX we have all info now.
```C++
int commandType //see commit for interpretation
float x
float y
float z
char targetId //if exists =EntityId
char blueprintId //for `build` command if exists
```

Exe (updated): https://mega.nz/file/AFZnGDCY#yMDaigGE-fBUNwWzwhFSCV87RvBwEZPr-NKZ8e0L6b0
