### PR TITLE
Fix Unit:SetStat

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This are just the patch files for this game. I decided to separate them from pat
 
 # Change List
 ## Fixes
+- Fix `Unit:SetStat` function, crashed before. Now returns true if value must be set.
+    - hooks/SetStatFix.cpp
+    - section/SetStatFix.cpp
 - Upgrade Progress Fix
     - hooks/HUpgradeProgressFix.cpp
     - section/UpgradeProgressFix.cpp

--- a/hooks/SetStatFix.cpp
+++ b/hooks/SetStatFix.cpp
@@ -1,0 +1,7 @@
+#include "../define.h"
+asm(
+  ".section h0; .set h0,0x6CCA2A;"
+  "jmp "QU(SetStatCheck)";"
+  "nop;"
+  "nop;"
+);

--- a/section/SetStatFix.cpp
+++ b/section/SetStatFix.cpp
@@ -1,0 +1,31 @@
+#include "include/moho.h"
+
+void PushTrue()
+{
+    register lua_State *l asm("eax");
+    lua_pushboolean(l, true);
+}
+
+void SetStatCheck()
+{
+    asm(
+        // mov    ebx, eax //pointer to our stat in other thread
+        "mov     eax, [edi];" // pointer to lua state
+        "cmp ebx, 0;"
+        "je SetStatCheck_invalid;" // go to return 1
+        "mov     esi, 3;"
+        "jmp 0x6CCA31;" // get back into normal function flow
+        "SetStatCheck_invalid:"
+        "call %[PushTrue];"
+        "mov eax, 1;"
+        "pop     edi;"
+        "pop     esi;"
+        "pop     ebx;"
+        "mov     esp, ebp;"
+        "pop     ebp;"
+        "ret;"
+        :
+        : [PushTrue] "i"(PushTrue)
+        :
+        );
+}


### PR DESCRIPTION
Returns `true` if there is no such stat to be done like this:
```lua
if unit:SetStat("a", 4) then
  unit:GetStat("a", 4)
end
```
Tried to redirect to `Unit:GetStat`, didnt work for some reason...