### PR TITLE
Forbid passing a `cfunction` into `ForkThread`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This are just the patch files for this game. I decided to separate them from pat
 
 # Change List
 ## Fixes
+- Fix `ForkThread` function. Allow only lua function to be passed as first argument.
+    - hooks/ForkThreadFix.cpp
+    - section/ForkThreadFix.cpp
 - Fix `Unit:SetStat` function, crashed before. Now returns true if value must be set.
     - hooks/SetStatFix.cpp
     - section/SetStatFix.cpp

--- a/hooks/ForkThreadFix.cpp
+++ b/hooks/ForkThreadFix.cpp
@@ -1,0 +1,5 @@
+#include "../define.h"
+asm(
+  ".section h0; .set h0,0x4C9DE1;"
+  "call "QU(IsLuaFunction)";"
+);

--- a/section/ForkThreadFix.cpp
+++ b/section/ForkThreadFix.cpp
@@ -1,0 +1,23 @@
+#include "include/moho.h"
+
+void IsLuaFunction()
+{
+    asm(
+        "sub     esp, 0x28;"
+        "cmp     dword ptr [ecx+8], 0;"
+        "jnz     loc_907836;"
+        "push    offset 0xD44C30; "
+        "lea     ecx, [esp+0x2C-0x28];"
+        "call    0x457880;"// luaplus_assert
+        "push    0xEC23F0 ;"
+        "lea     eax, [esp+0x2C-0x28];"
+        "push    eax             ; "
+        "call    0xA89950 ;"//__CxxThrowException
+        "loc_907836: ;"
+        "mov     ecx, [ecx+0x0C];"
+        "xor     eax, eax;"
+        "cmp     ecx, 7;" // check for lua function
+        "setz    al;"
+        "add     esp, 0x28;"
+        "ret;");
+}


### PR DESCRIPTION
`ForkThread` crashes when used with **any** of cfunction.
```lua
ForkThread(LOG, "hello!")
```
After patch it no longer accepts cfunction as fisrt argument. The valid code:
```lua
ForkThread(function(msg) LOG(msg) end, "hello!")
```