### PR TITLE
Allow multiple collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ https://github.com/FAForever/FA_Patcher
 - See `SigPatches.txt`
 ## Fixes
 - Allows multiple collisions to be processed during collision checks.
+    - hooks/FixCollisions.cpp
 - Fix `CMauiControl:SetAlpha`: don't change color part and check for 3rd argument as boolean.
     - hooks/SetAlpha.cpp
     - section/SetAlpha.cpp

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://github.com/FAForever/FA_Patcher
 ## Signature patches
 - See `SigPatches.txt`
 ## Fixes
+- Allows multiple collisions to be processed during collision checks.
 - Fix `CMauiControl:SetAlpha`: don't change color part and check for 3rd argument as boolean.
     - hooks/SetAlpha.cpp
     - section/SetAlpha.cpp

--- a/hooks/FixCollisions.cpp
+++ b/hooks/FixCollisions.cpp
@@ -1,0 +1,8 @@
+#include "../define.h"
+// This skips the check that makes entries after the first one in the collision
+// results list only considered when that entry is the last entry's shield
+asm(
+  // Moho::Projectile::CheckCollision+0x96E
+  ".section h0; .set h0,0x69DB3E;"
+  "JMP .+0x6D;"
+);


### PR DESCRIPTION
Allows the closest collision of a projectile to be the impact when it has multiple potential collision results in a single tick.