### PR TITLE
Measure unit collisions properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ https://github.com/FAForever/FA_Patcher
     - hooks/LuaFuncRegs.cpp
     - section/LuaFuncRegs.cpp
 ## Fixes
+- Projectiles measure unit collision distance properly.
 - Allows multiple collisions to be processed during collision checks.
     - hooks/FixCollisions.cpp
 - Fix `CMauiControl:SetAlpha`: don't change color part and check for 3rd argument as boolean.

--- a/hooks/FixCollisions.cpp
+++ b/hooks/FixCollisions.cpp
@@ -11,7 +11,7 @@ asm(R"(
 
 # change the 10% velocity offset for unit collision lines to 0% so the distance
 # is measured properly
-.section h5; .set h5,0x69DA6A
-	movss   xmm7, dword ptr [0xE4F7E0]
+.section h5; .set h5,0x69DA6A #Moho::Projectile::CheckCollision+0x89A
+	movss   xmm7, dword ptr [0xE4F7E0] # zero
 
 )");

--- a/hooks/FixCollisions.cpp
+++ b/hooks/FixCollisions.cpp
@@ -6,3 +6,12 @@ asm(
   ".section h0; .set h0,0x69DB3E;"
   "JMP .+0x6D;"
 );
+
+asm(R"(
+
+# change the 10% velocity offset for unit collision lines to 0% so the distance
+# is measured properly
+.section h5; .set h5,0x69DA6A
+	movss   xmm7, dword ptr [0xE4F7E0]
+
+)");


### PR DESCRIPTION
The collision line projectiles use for units is shifted backwards by 0.1 of the velocity. This PR removes that.