### PR TITLE
Fix custom world rendering feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To apply the patches you can use the upload action or do it local via the [patch
     - `UI_DrawRect(pos:vector, size:float, color:string, thickness?=0.15:float)`
     - `UI_DrawCircle(pos:vector, radius:float, color:string, thickness?=0.15:float)`
   
-    Both functions must be called within `OnRenderWorld(delta_time)` of `gamemain.lua`. CWR can be enabled with console command `ui_CustomWorldRendering`.
+    Both functions must be called within `WorldView.OnRenderWorld(delta_time)`. CWR can be enabled with console command `ui_CustomWorldRendering`.
 - Adds Strategic icon scale support:
     - hooks/IconScale.cpp
     - section/IconScale.cpp

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ To apply the patches you can use the upload action or do it local via the [patch
     - section/StopReclaimWhenPaused.cpp
 
 ## Additions
-- Adds Custom World Rendering (hooks: `HDraw.cpp`, `GetFPS.cpp`; section: `DrawFunc.cpp`, `DrawCircleSetColor.cpp`)
+- Adds Custom World Rendering (hooks: `HDraw.cpp`, `GetFPS.cpp`; section: `DrawFunc.cpp`, `DrawCircleSetColor.cpp`,`WorldView.cpp`)
     - `UI_DrawRect(pos:vector, size:float, color:string, thickness?=0.15:float)`
     - `UI_DrawCircle(pos:vector, radius:float, color:string, thickness?=0.15:float)`
   
-    Both functions must be called within `WorldView:OnRenderWorld(delta_time)`. CWR can be enabled with console command `ui_CustomWorldRendering`.
+    Both functions must be called within `WorldView:OnRenderWorld(delta_time)`. CWR can be enabled with console command `ui_CustomWorldRendering`. To enable CWR for WorldView call `WorldView:SetCustomRender(true)`. To disable call `WorldView:SetCustomRender(false)` respectively.
 - Adds Strategic icon scale support:
     - hooks/IconScale.cpp
     - section/IconScale.cpp

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To apply the patches you can use the upload action or do it local via the [patch
     - `UI_DrawRect(pos:vector, size:float, color:string, thickness?=0.15:float)`
     - `UI_DrawCircle(pos:vector, radius:float, color:string, thickness?=0.15:float)`
   
-    Both functions must be called within `WorldView:OnRenderWorld(delta_time)`. CWR can be enabled with console command `ui_CustomWorldRendering`. To enable CWR for WorldView call `WorldView:SetCustomRender(true)`. To disable call `WorldView:SetCustomRender(false)` respectively.
+    Both functions must be called within `WorldView:OnRenderWorld(delta_time)`. To enable CWR call `WorldView:SetCustomRender(true)` of WorldView you want to draw in. To disable call `WorldView:SetCustomRender(false)` respectively.
 - Adds Strategic icon scale support:
     - hooks/IconScale.cpp
     - section/IconScale.cpp

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To apply the patches you can use the upload action or do it local via the [patch
     - `UI_DrawRect(pos:vector, size:float, color:string, thickness?=0.15:float)`
     - `UI_DrawCircle(pos:vector, radius:float, color:string, thickness?=0.15:float)`
   
-    Both functions must be called within `WorldView.OnRenderWorld(delta_time)`. CWR can be enabled with console command `ui_CustomWorldRendering`.
+    Both functions must be called within `WorldView:OnRenderWorld(delta_time)`. CWR can be enabled with console command `ui_CustomWorldRendering`.
 - Adds Strategic icon scale support:
     - hooks/IconScale.cpp
     - section/IconScale.cpp

--- a/hooks/WorldViewCustomRender.cpp
+++ b/hooks/WorldViewCustomRender.cpp
@@ -1,0 +1,7 @@
+#include "../define.h"
+asm(
+  ".section h0; .set h0,0x86E5B2;"
+  "mov [edi+0x178], ebx;"
+);
+
+  

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -260,7 +260,11 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     //     return;
     if (!CustomWorldRendering)
         return;
+        
     worldview = _this;
+
+    if (!*(char *)((int)worldview + 377 - 284))//check for custom render enabled (see WorldView.cpp)
+        return;
 
     // LogF("%p", *(int *)(0x010A6470));//gamesession
     // LogF("%p", *(int *)((int)worldview - 284 + 532));
@@ -268,8 +272,6 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     LuaState *state = *(LuaState **)((int)g_CUIManager + 48);
     lua_State *l = state->m_state;
     LuaObject *view = (LuaObject *)((int)worldview - 284 + 32);
-    if (!*(char *)((int)worldview + 377 - 284))//check for custom render enabled (see WorldView.cpp)
-        return;
     // Moho::Import(l, "/lua/ui/game/gamemain.lua");
     view->PushStack(l);
     lua_pushstring(l, "OnRenderWorld");

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -268,6 +268,8 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     LuaState *state = *(LuaState **)((int)g_CUIManager + 48);
     lua_State *l = state->m_state;
     LuaObject *view = (LuaObject *)((int)worldview - 284 + 32);
+    if (!*(char *)((int)worldview + 377 - 284))//check for custom render enabled (see WorldView.cpp)
+        return;
     // Moho::Import(l, "/lua/ui/game/gamemain.lua");
     view->PushStack(l);
     lua_pushstring(l, "OnRenderWorld");

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -265,17 +265,16 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     // LogF("%p", *(int *)(0x010A6470));//gamesession
     // LogF("%p", *(int *)((int)worldview - 284 + 532));
 
-    
     LuaState *state = *(LuaState **)((int)g_CUIManager + 48);
     lua_State *l = state->m_state;
     LuaObject *view = (LuaObject *)((int)worldview - 284 + 32);
-    //Moho::Import(l, "/lua/ui/game/gamemain.lua");
+    // Moho::Import(l, "/lua/ui/game/gamemain.lua");
     view->PushStack(l);
     lua_pushstring(l, "OnRenderWorld");
     lua_gettable(l, -2);
     if (!lua_isfunction(l, -1))
     {
-        //WarningF("%s", "OnRenderWorld not a function");
+        // WarningF("%s", "OnRenderWorld not a function");
         return;
     }
     int *device = Moho::D3D_GetDevice();
@@ -292,6 +291,7 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     {
         WarningF("%s", lua_tostring(l, -1));
     }
+    lua_pop(l, 1);
     is_in_render_world = false;
     Moho::CPrimBatcher::FlushBatcher(batcher);
 }

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -174,12 +174,12 @@ namespace IWldTerrainRes
 } // namespace  IWldTerrainRes
 bool is_in_render_world = false;
 
-void *worldview = nullptr;
+void *_worldview = nullptr;
 // UI_Lua DrawRect()
 int LuaDrawRect(lua_State *l)
 {
     int *batcher = *(int **)(((int *)g_WRenViewport) + 2135);
-    if (batcher == nullptr || worldview == nullptr)
+    if (batcher == nullptr || _worldview == nullptr)
     {
         return 0;
     }
@@ -200,7 +200,7 @@ int LuaDrawRect(lua_State *l)
         return 0;
     }
     Vector3f orientation{0, 1, 0};
-    float lod = Moho::GetLODMetric((float *)Moho::GetWorldCamera(worldview), pos);
+    float lod = Moho::GetLODMetric((float *)Moho::GetWorldCamera(_worldview), pos);
     float thick = std::max(thickness / lod, 2.f);
     Vector3f a{0, 0, size};
     Vector3f b{size, 0, 0};
@@ -213,7 +213,7 @@ UIRegFunc DrawRectReg{"UI_DrawRect", "UI_DrawRect(pos:vector, size:float, color:
 int LuaDrawCircle(lua_State *l)
 {
     int *batcher = *(int **)(((int *)g_WRenViewport) + 2135);
-    if (batcher == nullptr || worldview == nullptr)
+    if (batcher == nullptr || _worldview == nullptr)
     {
         return 0;
     }
@@ -233,7 +233,7 @@ int LuaDrawCircle(lua_State *l)
         return 0;
     }
     Vector3f orientation{0, 1, 0};
-    float lod = Moho::GetLODMetric((float *)Moho::GetWorldCamera(worldview), pos);
+    float lod = Moho::GetLODMetric((float *)Moho::GetWorldCamera(_worldview), pos);
     float a = std::max(thickness / lod, 2.f);
     _DrawCircle(batcher, &pos, r, lod * a, color, &orientation);
 
@@ -261,9 +261,9 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     if (!CustomWorldRendering)
         return;
         
-    worldview = _this;
+    _worldview = _this;
 
-    if (!*(char *)((int)worldview + 377 - 284))//check for custom render enabled (see WorldView.cpp)
+    if (!*(char *)((int)_worldview + 377 - 284))//check for custom render enabled (see WorldView.cpp)
         return;
 
     // LogF("%p", *(int *)(0x010A6470));//gamesession
@@ -271,7 +271,7 @@ void __thiscall CustomDraw(void *_this, void *batcher)
 
     LuaState *state = *(LuaState **)((int)g_CUIManager + 48);
     lua_State *l = state->m_state;
-    LuaObject *view = (LuaObject *)((int)worldview - 284 + 32);
+    LuaObject *view = (LuaObject *)((int)_worldview - 284 + 32);
     // Moho::Import(l, "/lua/ui/game/gamemain.lua");
     view->PushStack(l);
     lua_pushstring(l, "OnRenderWorld");
@@ -284,7 +284,7 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     int *device = Moho::D3D_GetDevice();
     Moho::SetupDevice(device, "primbatcher", "TAlphaBlendLinearSampleNoDepth");
     Moho::CPrimBatcher::ResetBatcher(batcher);
-    Moho::CPrimBatcher::SetViewProjMatrix(batcher, Moho::GetWorldCamera(worldview));
+    Moho::CPrimBatcher::SetViewProjMatrix(batcher, Moho::GetWorldCamera(_worldview));
     Moho::CPrimBatcher::Texture t;
     Moho::CPrimBatcher::FromSolidColor(&t, 0xFFFFFFFF);
     Moho::CPrimBatcher::SetTexture(batcher, &t);
@@ -299,7 +299,7 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     lua_pop(l, 1);
     is_in_render_world = false;
     Moho::CPrimBatcher::FlushBatcher(batcher);
-    worldview = nullptr;
+    _worldview = nullptr;
 }
 
 int SetCustomRender(lua_State *l)

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -78,7 +78,7 @@ namespace Moho
         lua_call(l, 1, 1);
     }
 
-    void *GetWorldCamera(void* worldview)
+    void *GetWorldCamera(void *worldview)
     {
         int *camera = *(int **)((int)worldview + 4);
         void *projmatrix = (*(void *(__thiscall **)(int *))(*camera + 8))(camera);
@@ -248,7 +248,7 @@ ConDescReg CustomWorldRenderingVar{"ui_CustomWorldRendering", "Enables custom wo
 
 float delta_frame = 0;
 
-// this world view?
+// offset +284 from CUIWorldView
 void __thiscall CustomDraw(void *_this, void *batcher)
 {
     // void *wldmap = IWldTerrainRes::GetWldMap();
@@ -261,14 +261,21 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     if (!CustomWorldRendering)
         return;
     worldview = _this;
+
+    // LogF("%p", *(int *)(0x010A6470));//gamesession
+    // LogF("%p", *(int *)((int)worldview - 284 + 532));
+
+    
     LuaState *state = *(LuaState **)((int)g_CUIManager + 48);
     lua_State *l = state->m_state;
-    Moho::Import(l, "/lua/ui/game/gamemain.lua");
+    LuaObject *view = (LuaObject *)((int)worldview - 284 + 32);
+    //Moho::Import(l, "/lua/ui/game/gamemain.lua");
+    view->PushStack(l);
     lua_pushstring(l, "OnRenderWorld");
-    lua_rawget(l, -2);
+    lua_gettable(l, -2);
     if (!lua_isfunction(l, -1))
     {
-        WarningF("%s", "OnRenderWorld not a function");
+        //WarningF("%s", "OnRenderWorld not a function");
         return;
     }
     int *device = Moho::D3D_GetDevice();

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -107,7 +107,7 @@ namespace Moho
             int b;
         };
 
-        void __stdcall FromSolidColor(Texture *t, unsigned int color) asm("0x4478C0");
+        void FromSolidColor(Texture *t, unsigned int color) asm("0x4478C0");
 
         Texture FromSolidColor(unsigned int color)
         {
@@ -320,6 +320,14 @@ int SetCustomRender(lua_State *l)
     worldview->SetCustomRenderingEnabled(state);
     return 0;
 }
+
+using WorldViewMethodReg = UIRegFunc<0x00E491E8, 0x00F8D88C>;
+
+WorldViewMethodReg WorldViewSetCustomRender{
+    "SetCustomRender",
+    "WorldView:SetCustomRender(bool)",
+    SetCustomRender,
+    "CUIWorldView"};
 
 void CustomDrawEnter()
 {

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -274,7 +274,8 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     lua_gettable(l, -2);
     if (!lua_isfunction(l, -1))
     {
-        // WarningF("%s", "OnRenderWorld not a function");
+        // pop worldviewTable and the value under 'OnRenderWorld' key
+        lua_pop(l, 2);
         return;
     }
     int *device = Moho::D3D_GetDevice();

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -302,6 +302,28 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     worldview = nullptr;
 }
 
+int SetCustomRender(lua_State *l)
+{
+    if (lua_gettop(l) != 2)
+    {
+        l->LuaState->Error(s_ExpectedButGot, __FUNCTION__, 2, lua_gettop(l));
+    }
+    Result<CUIWorldView> r = GetCScriptObject<CUIWorldView>(l, 1);
+    if (r.IsFail())
+    {
+        lua_pushstring(l, r.reason);
+        lua_error(l);
+        return 0;
+    }
+    void *worldview = r.object;
+    if (worldview == nullptr)
+        return 0;
+
+    bool state = lua_toboolean(l, 2);
+    *(char *)((int)worldview + 377) = state;
+    return 0;
+}
+
 void CustomDrawEnter()
 {
     asm(

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -179,7 +179,7 @@ void *worldview = nullptr;
 int LuaDrawRect(lua_State *l)
 {
     int *batcher = *(int **)(((int *)g_WRenViewport) + 2135);
-    if (batcher == nullptr)
+    if (batcher == nullptr || worldview == nullptr)
     {
         return 0;
     }
@@ -213,7 +213,7 @@ UIRegFunc DrawRectReg{"UI_DrawRect", "UI_DrawRect(pos:vector, size:float, color:
 int LuaDrawCircle(lua_State *l)
 {
     int *batcher = *(int **)(((int *)g_WRenViewport) + 2135);
-    if (batcher == nullptr)
+    if (batcher == nullptr || worldview == nullptr)
     {
         return 0;
     }
@@ -294,6 +294,7 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     lua_pop(l, 1);
     is_in_render_world = false;
     Moho::CPrimBatcher::FlushBatcher(batcher);
+    worldview = nullptr;
 }
 
 void CustomDrawEnter()

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -68,6 +68,8 @@ void _DrawCircle(void *batcher, Vector3f *pos, float radius, float thickness, ui
           NON_GENERAL_REG(radius)
         : "eax");
 }
+
+void *worldview = nullptr;
 namespace Moho
 {
     void Import(lua_State *l, const char *filename)
@@ -79,7 +81,7 @@ namespace Moho
 
     void *GetWorldCamera()
     {
-        int *camera = *(int **)((int)*((int *)g_WRenViewport + 2128) + 4);
+        int *camera = *(int **)((int)worldview + 4);
         void *projmatrix = (*(void *(__thiscall **)(int *))(*camera + 8))(camera);
         return projmatrix;
     }
@@ -258,7 +260,7 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     //     return;
     if (!CustomWorldRendering)
         return;
-
+    worldview = _this;
     LuaState *state = *(LuaState **)((int)g_CUIManager + 48);
     lua_State *l = state->m_state;
     Moho::Import(l, "/lua/ui/game/gamemain.lua");

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -286,8 +286,9 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     Moho::CPrimBatcher::SetTexture(batcher, &t);
 
     is_in_render_world = true;
+    lua_pushvalue(l, -2);
     lua_pushnumber(l, delta_frame);
-    if (lua_pcall(l, 1, 0))
+    if (lua_pcall(l, 2, 0))
     {
         WarningF("%s", lua_tostring(l, -1));
     }

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -243,9 +243,6 @@ int LuaDrawCircle(lua_State *l)
 
 UIRegFunc DrawCircleReg{"UI_DrawCircle", "UI_DrawCircle(pos:vector, radius:float, color:string, thickness?=0.15:float)", LuaDrawCircle};
 
-bool CustomWorldRendering = false;
-ConDescReg CustomWorldRenderingVar{"ui_CustomWorldRendering", "Enables custom world rendering", &CustomWorldRendering};
-
 float delta_frame = 0;
 
 // offset +284 from CUIWorldView
@@ -258,12 +255,10 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     // void *map = IWldTerrainRes::GetMap(terrain);
     // if (!map)
     //     return;
-    if (!CustomWorldRendering)
-        return;
-        
+
     _worldview = _this;
 
-    if (!*(char *)((int)_worldview + 377 - 284))//check for custom render enabled (see WorldView.cpp)
+    if (!*(char *)((int)_worldview + 377 - 284)) // check for custom render enabled (see WorldView.cpp)
         return;
 
     // LogF("%p", *(int *)(0x010A6470));//gamesession

--- a/section/DrawFunc.cpp
+++ b/section/DrawFunc.cpp
@@ -257,8 +257,9 @@ void __thiscall CustomDraw(void *_this, void *batcher)
     //     return;
 
     _worldview = _this;
+    CUIWorldView *view = (CUIWorldView *)((int)_worldview - 284);
 
-    if (!*(char *)((int)_worldview + 377 - 284)) // check for custom render enabled (see WorldView.cpp)
+    if (!view->GetCustomRenderingEnabled())
         return;
 
     // LogF("%p", *(int *)(0x010A6470));//gamesession
@@ -266,9 +267,9 @@ void __thiscall CustomDraw(void *_this, void *batcher)
 
     LuaState *state = *(LuaState **)((int)g_CUIManager + 48);
     lua_State *l = state->m_state;
-    LuaObject *view = (LuaObject *)((int)_worldview - 284 + 32);
+    LuaObject *worldviewTable = (LuaObject *)((int)_worldview - 284 + 32);
     // Moho::Import(l, "/lua/ui/game/gamemain.lua");
-    view->PushStack(l);
+    worldviewTable->PushStack(l);
     lua_pushstring(l, "OnRenderWorld");
     lua_gettable(l, -2);
     if (!lua_isfunction(l, -1))
@@ -310,12 +311,12 @@ int SetCustomRender(lua_State *l)
         lua_error(l);
         return 0;
     }
-    void *worldview = r.object;
+    CUIWorldView *worldview = r.object;
     if (worldview == nullptr)
         return 0;
 
     bool state = lua_toboolean(l, 2);
-    *(char *)((int)worldview + 377) = state;
+    worldview->SetCustomRenderingEnabled(state);
     return 0;
 }
 

--- a/section/WorldView.cpp
+++ b/section/WorldView.cpp
@@ -25,7 +25,8 @@ Vector2f ProjectVec(const Vector3f &v, float *camera)
 void ProjectVectors(lua_State *l, int index, float *camera)
 {
     const char *t = (const char *)lua_topointer(l, index);
-    uint32_t asize; uint8_t hbits;
+    uint32_t asize;
+    uint8_t hbits;
     GetTableAH(t, &asize, &hbits);
     lua_createtable(l, asize, hbits); // result table
     lua_pushvalue(l, index);          // input vectors
@@ -84,4 +85,32 @@ WorldViewMethodReg WorldViewProjectMultiple{
     "ProjectMultiple",
     "WorldView:ProjectMultiple(vectors)",
     ProjectMultiple,
+    "CUIWorldView"};
+
+int SetCustomRender(lua_State *l)
+{
+    if (lua_gettop(l) != 2)
+    {
+        l->LuaState->Error(s_ExpectedButGot, __FUNCTION__, 2, lua_gettop(l));
+    }
+    Result<CUIWorldView> r = GetCScriptObject<CUIWorldView>(l, 1);
+    if (r.IsFail())
+    {
+        lua_pushstring(l, r.reason);
+        lua_error(l);
+        return 0;
+    }
+    void *worldview = r.object;
+    if (worldview == nullptr)
+        return 0;
+
+    bool state = lua_toboolean(l, 2);
+    *(char *)((int)worldview + 377) = state;
+    return 0;
+}
+
+WorldViewMethodReg WorldViewSetCustomRender{
+    "SetCustomRender",
+    "WorldView:SetCustomRender(bool)",
+    SetCustomRender,
     "CUIWorldView"};

--- a/section/WorldView.cpp
+++ b/section/WorldView.cpp
@@ -86,11 +86,3 @@ WorldViewMethodReg WorldViewProjectMultiple{
     "WorldView:ProjectMultiple(vectors)",
     ProjectMultiple,
     "CUIWorldView"};
-
-int SetCustomRender(lua_State *l);
-
-WorldViewMethodReg WorldViewSetCustomRender{
-    "SetCustomRender",
-    "WorldView:SetCustomRender(bool)",
-    SetCustomRender,
-    "CUIWorldView"};

--- a/section/WorldView.cpp
+++ b/section/WorldView.cpp
@@ -87,27 +87,7 @@ WorldViewMethodReg WorldViewProjectMultiple{
     ProjectMultiple,
     "CUIWorldView"};
 
-int SetCustomRender(lua_State *l)
-{
-    if (lua_gettop(l) != 2)
-    {
-        l->LuaState->Error(s_ExpectedButGot, __FUNCTION__, 2, lua_gettop(l));
-    }
-    Result<CUIWorldView> r = GetCScriptObject<CUIWorldView>(l, 1);
-    if (r.IsFail())
-    {
-        lua_pushstring(l, r.reason);
-        lua_error(l);
-        return 0;
-    }
-    void *worldview = r.object;
-    if (worldview == nullptr)
-        return 0;
-
-    bool state = lua_toboolean(l, 2);
-    *(char *)((int)worldview + 377) = state;
-    return 0;
-}
+int SetCustomRender(lua_State *l);
 
 WorldViewMethodReg WorldViewSetCustomRender{
     "SetCustomRender",

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -203,6 +203,16 @@ struct CUIWorldView : CMauiControl
 	// at 0x208
 	CWldSession *session;
 	void *unk1; // If shift pressed
+
+	bool GetCustomRenderingEnabled()const
+	{
+		return *(char*)((int)this + 377);
+	}
+
+	void SetCustomRenderingEnabled(bool state)
+	{
+		*(char*)((int)this + 377) = state;
+	}
 };
 
 struct RBlueprint;


### PR DESCRIPTION
* get worldview pointer from arguments
* use `OnRenderWorld` of the worldview
* custom world rendering works when `SetCustomRendering` is set to true

Example:
```lua
viewLeft.OnRenderWorld = function(self, delta)
        UI_DrawCircle(GetMouseWorldPos(), 10, 'ffffffff', 0.3)
end
viewLeft:SetCustomRender(true)
```