### PR TITLE
Reduce intel update interval

### DIFF
--- a/hooks/IntelUpdate.cpp
+++ b/hooks/IntelUpdate.cpp
@@ -1,0 +1,22 @@
+#include "../define.h"
+
+asm(R"(
+
+#Moho::CIntelPosHandle::UpdatePos at 0x76F1E0
+# Intel handles update the intel raster grid when one of the following two
+# conditions are met:
+#   * The unit has moved more than a certain ratio of the intel radius beyond
+#     the last update position
+    radius_movement_ratio = 0xE4F6EC # 0.25 from 0.33
+#   * a certain number of ticks have passed since the last update
+    tick_update_interval = 5 # from 30
+
+
+# We'll leave this alone for now.
+#.section h0; .set h0,0x76F21A #Moho::CIntelPosHandle::UpdatePos+0x3A
+#   fmul dword ptr [radius_movement_ratio]
+
+.section h1; .set h1,0x76F258 #Moho::CIntelPosHandle::UpdatePos+0x78
+    cmp edx, tick_update_interval
+
+)");


### PR DESCRIPTION
Currently, units only update the intel grid when either 30 ticks have passed or they have moved 33% of their intel radius. This PR reduces that time down to 5 ticks. This likely means that the intel radius ratio can be changed or even removed altogether, but it is currently left alone for teleportation and edge cases with mods.