### PR TITLE
ProjectileNewMethods

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,15 @@ To apply the patches you can use the upload action or do it local via the [patch
     - section/StopReclaimWhenPaused.cpp
 
 ## Additions
+- Adds new methods to the the `Projectile` class (section/ProjectileNewMethods.cpp):
+    - `Projectile:SetNewTargetGroundXYZ(x, y, z)`
+    - `x, y, z = Projectile:GetCurrentTargetPositionXYZ()`
+    - `frequency = Projectile:GetZigZagFrequency()`
+    - `maxzigzag = Projectile:GetMaxZigZag()`
 - Adds Custom World Rendering (hooks: `HDraw.cpp`, `GetFPS.cpp`; section: `DrawFunc.cpp`, `DrawCircleSetColor.cpp`,`WorldView.cpp`)
     - `UI_DrawRect(pos:vector, size:float, color:string, thickness?=0.15:float)`
     - `UI_DrawCircle(pos:vector, radius:float, color:string, thickness?=0.15:float)`
-  
+
     Both functions must be called within `WorldView:OnRenderWorld(delta_time)`. To enable CWR call `WorldView:SetCustomRender(true)` of WorldView you want to draw in. To disable call `WorldView:SetCustomRender(false)` respectively.
 - Adds Strategic icon scale support:
     - hooks/IconScale.cpp

--- a/section/ProjectileNewMethods.cpp
+++ b/section/ProjectileNewMethods.cpp
@@ -1,0 +1,100 @@
+#include "include/global.h"
+#include "include/moho.h"
+#include "include/CObject.h"
+#include "include/magic_classes.h"
+
+int GetMaxZigZag(lua_State *L) {
+    auto res = GetCScriptObject<Projectile>(L, 1);
+    if (res.IsFail())
+        L->LuaState->Error("%s", res.reason);
+    auto projectile = reinterpret_cast<uintptr_t>(res.object);
+    lua_pushnumber(L, *reinterpret_cast<float*>(projectile + 0x36C));
+    return 1;
+}
+
+int GetZigZagFrequency(lua_State *L) {
+    auto res = GetCScriptObject<Projectile>(L, 1);
+    if (res.IsFail())
+        L->LuaState->Error("%s", res.reason);
+    auto projectile = reinterpret_cast<uintptr_t>(res.object);
+    lua_pushnumber(L, *reinterpret_cast<float*>(projectile + 0x370));
+    return 1;
+}
+
+int GetCurrentTargetPositionXYZ(lua_State *L) {
+    auto res = GetCScriptObject<Projectile>(L, 1);
+    if (res.IsFail())
+        L->LuaState->Error("%s", res.reason);
+    auto projectile = reinterpret_cast<uintptr_t>(res.object);
+    volatile Vector3f pos{};
+    if (*reinterpret_cast<uintptr_t*>(projectile + 0x2EC)) {
+        asm("call 0x5E2A90"
+            :
+            :"b"(0), "c"(projectile + 0x2EC), "a"(&pos)
+            :);
+    }
+    lua_pushnumber(L, pos.x);
+    lua_pushnumber(L, pos.y);
+    lua_pushnumber(L, pos.z);
+    return 3;
+}
+
+int SetNewTargetGroundXYZ(lua_State *L) {
+    if (lua_gettop(L) != 4)
+        L->LuaState->Error(s_ExpectedButGot, __FUNCTION__, 4, lua_gettop(L));
+    auto res = GetCScriptObject<Projectile>(L, 1);
+    if (res.IsFail())
+        L->LuaState->Error("%s", res.reason);
+
+    volatile struct target_details {
+        uint32_t mode;
+        void *unit; //-0xC
+        uint32_t dword8;
+        float x, y, z;
+        int dword18;
+        char byte1C;
+    } details;
+
+    details.x = lua_tonumber(L, 2);
+    details.y = lua_tonumber(L, 3);
+    details.z = lua_tonumber(L, 4);
+
+    details.mode = 2;
+    details.unit = 0;
+    details.dword8 = 0;
+    details.dword18= -1;
+    details.byte1C = 0;
+
+    auto projectile = reinterpret_cast<uintptr_t>(res.object);
+    asm("call 0x5D5670"
+        :
+        :"a"(projectile + 0x2EC), "S"(&details)
+        :);
+    return 0;
+}
+
+using ProjectileMethodReg = SimRegFunc<0xE2A0DC, 0xF8D784>;
+
+ProjectileMethodReg ProjectileGetMaxZigZag{
+    "GetMaxZigZag",
+    "zigzag = Projectile:GetMaxZigZag()",
+    GetMaxZigZag,
+    "Projectile"};
+
+ProjectileMethodReg ProjectileGetZigZagFrequency{
+    "GetZigZagFrequency",
+    "frequency = Projectile:GetZigZagFrequency()",
+    GetZigZagFrequency,
+    "Projectile"};
+
+ProjectileMethodReg ProjectileGetCurrentTargetPositionXYZ{
+    "GetCurrentTargetPositionXYZ",
+    "x, y, z = Projectile:GetCurrentTargetPositionXYZ",
+    GetCurrentTargetPositionXYZ,
+    "Projectile"};
+
+ProjectileMethodReg ProjectileSetNewTargetGroundXYZ{
+    "SetNewTargetGroundXYZ",
+    "Projectile:SetNewTargetGroundXYZ(x, y, z)",
+    SetNewTargetGroundXYZ,
+    "Projectile"};

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -674,6 +674,7 @@ struct Entity : CScriptObject
 struct Projectile : Entity
 {//0x004C702B, 0x380 bytes
 	// at 0x6C
+	using Type = ObjectType<0x10C7578, 0xF77914>;
 	RProjectileBlueprint *Blueprint;
 };
 


### PR DESCRIPTION
Relates to:

* [Add `GetMaxZigZag` to the projectile class FA-Binary-Patches#57](https://github.com/FAForever/FA-Binary-Patches/issues/57)
* [Add `GetZigZagFrequency` to the projectile class FA-Binary-Patches#58](https://github.com/FAForever/FA-Binary-Patches/issues/58)
* [Add `GetCurrentTargetPositionXYZ` to the projectile class FA-Binary-Patches#59](https://github.com/FAForever/FA-Binary-Patches/issues/59)
* [Add `SetNewTargetGroundXYZ` to the projectile class  FA-Binary-Patches#60](https://github.com/FAForever/FA-Binary-Patches/issues/60)

