### PR TITLE
Fix Test Command Caps and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,47 @@ This are some binary patches for Supreme Commander Forged Alliance.
 To apply the patches you can use the upload action or do it local via the [patcher](https://github.com/FAForever/FA_Patcher)
 
 # Change List
+
 ## Signature patches
 - See `SigPatches.txt`
+
 ## Technical patches
+These don't matter except for other assembly patches
+
 - Adds `lua_createtable`
     - section/lua_createtable.cpp
 - Adds registrators for Sim and UI Lua funcs.
     - hooks/LuaFuncRegs.cpp
     - section/LuaFuncRegs.cpp
+
 ## Fixes
+These mainly make the game run faster
+
+### Optimizations
 - Optimize `VDist3` function
     - hooks/VDist3.cpp
     - section/VDist3.cpp
-- Projectiles measure unit collision distance properly.
-- Prevent projectile layer changes on terrain collisions.
+- Reduce call sim beat of UI
+    - hooks/HUIReduceCallSimBeat.cpp
+- Zeroing GuardScanRadius if the unit's order is not Patrol/AttackMove. Increases performance.
+    - hooks/HGuardFix.cpp
+    - section/GuardFix.cpp
+- Range ring performance improvement (reducing height cylinders)
+    - hooks/HRangeRings2.cpp
+    - section/RangeRings2.cpp
+- Range ring performance improvement (don't render each ring twice)
+    - hooks/RangeRings.cpp
+    - section/RangeRings.cpp
+- Camera performance improvements
+    - hooks/CameraPerf.cpp
+- Optimised some AI actions
+    - hooks/aiinitattack.cpp
+
+### Bugs
+- Make `TestCommandCaps` test commands caps instead of toggle caps
+    - hooks/FixTestCommandCaps.cpp
+- Reduce terrain collision distance-based offset to 1%;
+- Prevent projectile layer changes on terrain collisions;
 - Allows multiple collisions to be processed during collision checks.
     - hooks/FixCollisions.cpp
 - Fix `CMauiControl:SetAlpha`: don't change color part and check for 3rd argument as boolean.
@@ -35,29 +62,10 @@ To apply the patches you can use the upload action or do it local via the [patch
 - Upgrade Progress Fix
     - hooks/HUpgradeProgressFix.cpp
     - section/UpgradeProgressFix.cpp
-- Allows to use 4GB on x64
-    - hooks/HFix4GB.cpp
-- Reduce call sim beat of UI
-    - hooks/HUIReduceCallSimBeat.cpp
-- Removing CTRL formations
-    - hooks/HRemovingCTRLFormations.cpp
-- Ignore empty reclaim orders
-    - hooks/HIgnoreEmptyReclaim.cpp
-- Zeroing GuardScanRadius if the unit's order is not Patrol/AttackMove. Increases performance.
-    - hooks/HGuardFix.cpp
-    - section/GuardFix.cpp
 - Prevents the crash with 'None' collisions of air. #3235
     - hooks/AirNoneCollisionFix.cpp
 - Prevents commander exploding for no reason. #3406
     - hooks/NegativeIncomeFix.cpp
-- Range ring performance improvement (reducing height cylinders)
-    - hooks/HRangeRings2.cpp
-    - section/RangeRings2.cpp
-- Range ring performance improvement (don't render each ring twice)
-    - hooks/RangeRings.cpp
-    - section/RangeRings.cpp
-- Camera performance improvements
-    - hooks/CameraPerf.cpp
 - Fix replays desyncing when a player leaves the game
     - hooks/DesyncFix.cpp
     - section/gpg_net.cpp
@@ -66,26 +74,56 @@ To apply the patches you can use the upload action or do it local via the [patch
     - section/include/desync_fix_global.h
 - Kill exception during map loading
     - hooks/Kill_maploader_except.cpp
-- Make xact3d the error message print once
-    - hooks/xact_3dapply.cpp
-    - section/xact_3d_fix.cpp
 - Prevent blueprint editor being used without cheat mode
     - hooks/FixOpenBPEditor.cpp
 - Can't become an observer while your human allies are still alive
     - hooks/ObserverFix.cpp
-- Stop the engine calling lua every time a plane turns
-    - hooks/OnMotionTurnEvent.cpp
-- Optimised some AI actions
-    - hooks/aiinitattack.cpp
 - Fix a crash when units arrive at waypoints
     - hooks/WayPointArrive.cpp
+
+### Improvements
+- Allows to use 4GB on x64
+    - hooks/HFix4GB.cpp
+- Make xact3d the error message print once
+    - hooks/xact_3dapply.cpp
+    - section/xact_3d_fix.cpp
 - Improvements to lua messages
     - hooks/LuaMessages.cpp
+
+
+## Changes
+These change the way the game is played or interacted with by Lua
+
+### Gameplay
+
+- Change tick intel update interval from every 30 ticks to every 1 tick
+    - hooks/IntelUpdate.cpp
+- Removing CTRL formations
+    - hooks/HRemovingCTRLFormations.cpp
+- Ignore empty reclaim orders
+    - hooks/HIgnoreEmptyReclaim.cpp
 - Stops reclaim if unit is paused (similar to 'build', 'assist' etc.)
     - hooks/StopReclaimWhenPaused.cpp
     - section/StopReclaimWhenPaused.cpp
+    - section/selectionPriority.cpp
+- Allows changing army of ACUs
+    - hooks/HTransferACUs.cpp
+- Allow players to double-click to select Walls
+    - hooks/WallSelection.cpp
+- Make `LOWSELECTPRIO` apply to units under construction
+    - hooks/selectionPriority.cpp
+
+### Lua
+
+- Change `SUBCOMMANDER` category name to `SACU_BEHAVIOR` (FAF makes this transparent)
+    - hooks/CategoryRenames.cpp
+- Stop the engine calling lua every time a plane turns
+    - hooks/OnMotionTurnEvent.cpp
+
 
 ## Additions
+These new features have been added in a backwards compatibile manner
+
 - Adds new methods to the the `Projectile` class (section/ProjectileNewMethods.cpp):
     - `Projectile:SetNewTargetGroundXYZ(x, y, z)`
     - `x, y, z = Projectile:GetCurrentTargetPositionXYZ()`
@@ -106,7 +144,7 @@ To apply the patches you can use the upload action or do it local via the [patch
     - `GetFractionComplete` returns float from 0 to 1
 - Adds method `MauiBitmap` (section/MauiBitmap.cpp):
     - `SetColorMask`- sets color mask for bitmap
-- Adds 5th argumnet for `IssueMobileBuild` as flag whether to pick all units for build order
+- Adds 5th argument for `IssueMobileBuild` as flag whether to pick all units for build order
     - hooks/IssueMobileBuild.cpp
     - section/IssueMobileBuild.cpp
 - Adds GetProcessAffinityMask, SetProcessAffinityMask, SetProcessPriority to "init.lua"
@@ -121,8 +159,6 @@ To apply the patches you can use the upload action or do it local via the [patch
 - Adds new category 'OBSTRUCTSBUILDING' for props to block buildings from being build on top of those
     - hooks/Reclaimable.cpp
     - section/Categories.cpp
-- Allows changing army of ACUs
-    - hooks/HTransferACUs.cpp
 - Allows customize colors for team color mode
     - hooks/TeamColorMode.cpp
     - section/TeamColorMode.cpp
@@ -135,8 +171,6 @@ To apply the patches you can use the upload action or do it local via the [patch
 - Console command: "cam_DefaultMiniLOD 0" now disable mesh renderer for minimap
     - hooks/MinimapMesh.cpp
     - section/MinimapMesh.cpp
-- Allow players to double-click to select Walls
-    - hooks/WallSelection.cpp
 - Adds GetTimeForProfile to Sim and UI. Allows to deal with the loss of accuracy
     - section/GetTimeForProfile.cpp
     - section/LuaFuncRegs.cpp
@@ -149,9 +183,6 @@ To apply the patches you can use the upload action or do it local via the [patch
 - Adds an amphibious mode toggle to the Salem
     - hooks/luaSimGetStat.cpp
     - section/luaSimGetStat.cpp
-- Make `LOWSELECTPRIO` apply to units under construction
-    - hooks/selectionPriority.cpp
-    - section/selectionPriority.cpp
 - Adds GetDepositsAroundPoint to Sim and UI
     - section/SimGetDepositsAroundPoint.cpp
     - section/LuaFuncRegs.cpp

--- a/hooks/FixTestCommandCaps.cpp
+++ b/hooks/FixTestCommandCaps.cpp
@@ -1,5 +1,5 @@
 asm(R"(
-.section h0; .set h0,0x06C8B48
+.section h0; .set h0,0x06C8B48 #Moho::UnitTestCommandCaps_LuaFuncDef+0xD8
     #test    [eax+180h], ecx   # test toggle caps
     test    [eax+17Ch], ecx    # test command caps
 )");

--- a/hooks/FixTestCommandCaps.cpp
+++ b/hooks/FixTestCommandCaps.cpp
@@ -1,0 +1,5 @@
+asm(R"(
+.section h0; .set h0,0x06C8B48
+    #test    [eax+180h], ecx   # test toggle caps
+    test    [eax+17Ch], ecx    # test command caps
+)");

--- a/hooks/FixTestCommandCaps.cpp
+++ b/hooks/FixTestCommandCaps.cpp
@@ -1,5 +1,5 @@
 asm(R"(
 .section h0; .set h0,0x06C8B48 #Moho::UnitTestCommandCaps_LuaFuncDef+0xD8
-    #test    [eax+180h], ecx   # test toggle caps
-    test    [eax+17Ch], ecx    # test command caps
+    #test    [eax+0x180], ecx   # test toggle caps
+    test    [eax+0x17C], ecx    # test command caps
 )");


### PR DESCRIPTION
`Unit:TestCommandCaps` and `Unit:TestToggleCaps` current both check the blueprint's `General.ToggleCaps` - this patch fixes that so that testing command caps correctly checks `General.CommandCaps`. Updates the README for better organization.