### PR TITLE
Fix `CUIWorldMesh:GetInterpolatedAlignedBox` return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To apply the patches you can use the upload action or do it local via the [patch
     - hooks/LuaFuncRegs.cpp
     - section/LuaFuncRegs.cpp
 ## Fixes
+- Fix CUIWorldMesh:GetInterpolatedAlignedBox return table to properly store `ymax` and `zMax`
+    - hooks/FixGetInterpolatedAlignedBox.cpp
 - Optimize `VDist3` function
     - hooks/VDist3.cpp
     - section/VDist3.cpp

--- a/hooks/FixGetInterpolatedAlignedBox.cpp
+++ b/hooks/FixGetInterpolatedAlignedBox.cpp
@@ -1,0 +1,9 @@
+#include "../define.h"
+
+asm(R"(
+.section h0; .set h0,0x086D2C0 #cfunc_CUIWorldMeshGetInterpolatedAlignedBox+0x150
+    push offset )" QU(strYMax) R"( # "yMax" from "xMax"
+
+.section h1; .set h1,0x086D2D6 #cfunc_CUIWorldMeshGetInterpolatedAlignedBox+0x166
+    push offset )" QU(strZMax) R"( # "zMax" from "xMax"
+)");

--- a/section/Strings.cpp
+++ b/section/Strings.cpp
@@ -1,2 +1,4 @@
 char OBSTRUCTSBUILDING[] = "OBSTRUCTSBUILDING";
 char CANLANDONWATER [] = "CANLANDONWATER";
+char strYMax[] = "yMax";
+char strZMax[] = "zMax";


### PR DESCRIPTION
`CUIWorldMesh:GetInterpolatedAlignedBox` previously returned a table like
```
{
  xMin = meshInstance->xMin
  yMin = meshInstance->yMin
  zMin = meshInstance->zMin
  xMax = meshInstance->xMax
  xMax = meshInstance->yMax // bad!
  xMax = meshInstance->zMax // wrong field!
}
```
Now it correctly does
```
{
  xMin = meshInstance->xMin
  yMin = meshInstance->yMin
  zMin = meshInstance->zMin
  xMax = meshInstance->xMax
  yMax = meshInstance->yMax
  zMax = meshInstance->zMax
}
```