### PR TITLE
Revert "Update intelligence every tick"

### DIFF
--- a/hooks/IntelUpdate.cpp
+++ b/hooks/IntelUpdate.cpp
@@ -2,23 +2,21 @@
 
 asm(R"(
 
+#Moho::CIntelPosHandle::UpdatePos at 0x76F1E0
+# Intel handles update the intel raster grid when one of the following two
+# conditions are met:
+#   * The unit has moved more than a certain ratio of the intel radius beyond
+#     the last update position
+    radius_movement_ratio = 0xE4F6EC # 0.25 from 0.33
+#   * a certain number of ticks have passed since the last update
+    tick_update_interval = 5 # from 30
 
-# make intelligence update every tick
 
-.section h0; .set h0,0x76F1E0 #Moho::CIntelPosHandle::UpdatePos
-# void (__usercall*)(this@<edx>, int curTick@<eax>, Wm3::Vector3 *newPos@<ecx>)
-    push    ecx
-    push    ebx
-    push    esi
-    mov     esi, edx
-    cmp     byte ptr [esi+0x18], 0
-    mov     ebx, ecx
-    jz      short CLEANUP
-    mov     [esi+0x14], eax
-    call    0x76EFC0 #void __usercall Moho::CIntelPosHandle::Update(this@<esi>, Wm3::Vector3 *pos@<ebx>)
-CLEANUP:
-    pop     esi
-    pop     ebx
-    pop     ecx
-    ret
+# We'll leave this alone for now.
+#.section h0; .set h0,0x76F21A #Moho::CIntelPosHandle::UpdatePos+0x3A
+#   fmul dword ptr [radius_movement_ratio]
+
+.section h1; .set h1,0x76F258 #Moho::CIntelPosHandle::UpdatePos+0x78
+    cmp edx, tick_update_interval
+
 )");


### PR DESCRIPTION
Reverts FAForever/FA-Binary-Patches#63 so that we can release with the current 5 tick refresh rate.