### PR TITLE
Enable unused console commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ These don't matter except for other assembly patches
 ## Additions
 These new features have been added in a backwards compatibile manner
 
-- Enable unused console commands
+- Enable unused console commands: ren_Steering, dbg_Ballistics, dbg_EfxBeams, dbg_Trail, dbg_CollisionBeam, dbg_Projectile
     - hooks/EnableConsoleCommands.cpp
 - Adds `GetHighlightCommand() - return table of command or nil` to UI (section/GetHighlightCommand.cpp)
 - Adds new methods to the the `Projectile` class (section/ProjectileNewMethods.cpp):

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ These don't matter except for other assembly patches
 ## Additions
 These new features have been added in a backwards compatibile manner
 
+- Enable unused console commands
+    - hooks/EnableConsoleCommands.cpp
 - Adds `GetHighlightCommand() - return table of command or nil` to UI (section/GetHighlightCommand.cpp)
 - Adds new methods to the the `Projectile` class (section/ProjectileNewMethods.cpp):
     - `Projectile:SetNewTargetGroundXYZ(x, y, z)`

--- a/hooks/EnableConsoleCommands.cpp
+++ b/hooks/EnableConsoleCommands.cpp
@@ -3,9 +3,11 @@
 asm(R"(
 	.section h0; .set h0,0xE1DF0C; .string "ren_Steering"
 	.section h1; .set h1,0xE210E8; .string "dbg_Ballistics"
-	.section h2; .set h2,0xE23900; .string "dbg_EfxBeams"
-	#.section h3; .set h3,0xE23EC4; .string "dbg_Emitter" # actually unused by the engine
-	.section h4; .set h4,0xE26858; .string "dbg_Trail"
-	.section h5; .set h5,0xE2698C; .string "dbg_CollisionBeam"
-	.section h6; .set h6,0xE294E8; .string "dbg_Projectile"
+	# just barely doesn't fit, slide up one into the empty description and update pointer
+	.section h2; .set h2,0xF59C88; .word 0xE23900 - 1
+	.section h3; .set h3,0xE23900 - 1; .string "dbg_EfxBeams"
+	#.section h4; .set h4,0xE23EC4; .string "dbg_Emitter" # actually unused by the engine
+	.section h5; .set h5,0xE26858; .string "dbg_Trail"
+	.section h6; .set h6,0xE2698C; .string "dbg_CollisionBeam"
+	.section h7; .set h7,0xE294E8; .string "dbg_Projectile"
 )");

--- a/hooks/EnableConsoleCommands.cpp
+++ b/hooks/EnableConsoleCommands.cpp
@@ -1,0 +1,11 @@
+// these are the locations of the names of fully registered commands - they're null,
+// so they don't work until we fill in the name
+asm(R"(
+	.section h0; .set h0,0xE1DF0C; .string "ren_Steering"
+	.section h1; .set h1,0xE210E8; .string "dbg_Ballistics"
+	.section h2; .set h2,0xE23900; .string "dbg_EfxBeams"
+	#.section h3; .set h3,0xE23EC4; .string "dbg_Emitter" # actually unused by the engine
+	.section h4; .set h4,0xE26858; .string "dbg_Trail"
+	.section h5; .set h5,0xE2698C; .string "dbg_CollisionBeam"
+	.section h6; .set h6,0xE294E8; .string "dbg_Projectile"
+)");


### PR DESCRIPTION
Adds the following console commands:
* `ren_Steering`
* `dbg_Ballistics` 
* `dbg_CollisionBeam`
* `dbg_EfxBeams`
* `dbg_Projectile`
* `dbg_Trail`