### PR TITLE
Remove transport load factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ These don't matter except for other assembly patches
     - hooks/aiinitattack.cpp
 
 ## Bugs
+- Remove lingering transport load factor calcuation at aircraft initialization
+    - hooks/RemoveTransportLoadFactor.cpp
 - Fix `RolloverInfo` returning integer economy values. 
     - hooks/GetRolloverInfoFix.cpp
 - Fix [problem described here](https://www.lua.org/bugs.html#5.0.2-5)

--- a/hooks/RemoveTransportLoadFactor.cpp
+++ b/hooks/RemoveTransportLoadFactor.cpp
@@ -1,4 +1,5 @@
 asm(
+    // Moho::Unit::CalcTransportLoadFactor
     ".section h0; .set h0,0x6A8B30;"
     "fld1;"
     "ret;"

--- a/hooks/RemoveTransportLoadFactor.cpp
+++ b/hooks/RemoveTransportLoadFactor.cpp
@@ -1,0 +1,5 @@
+asm(
+    ".section h0; .set h0,0x6A8B30;"
+    "fld1;"
+    "ret;"
+);


### PR DESCRIPTION
There was lingering code in the engine to calculate the "transport load factor" (how much the transport slows down given the weight of the units inside) when an aircraft first moves - this was causing issues with some survival maps that spawn transports with units inside now that we've change the `AverageDensity` blueprint value of units. This PR makes the load factor always return `1.0`.
