### PR TITLE
Enable class 4 attach points

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ These don't matter except for other assembly patches
     - hooks/aiinitattack.cpp
 
 ## Bugs
+- Enable Class 4 attach points ("AttachPoint_Spr" bones)
+    - hooks/Class4AttachSize.cpp
 - Remove lingering transport load factor calcuation at aircraft initialization
     - hooks/RemoveTransportLoadFactor.cpp
 - Fix `RolloverInfo` returning integer economy values. 

--- a/hooks/Class4AttachSize.cpp
+++ b/hooks/Class4AttachSize.cpp
@@ -1,0 +1,6 @@
+asm(
+    // Moho::CAiTransportImpl::"GetAttachPointsFor"+0xAA (switch case Moho::ETransportClass::TRANSPORTCLASS_4)  
+    ".section h0; .set h0,0x5E6BDA;"
+    "jmp .+0x1F;" // add break to case so it doesn't fall-through and get overriden by TRANSPORTCLASS_SPECIAL
+    // by utilizing output assignment of case TRANSPORTCLASS_3/TRANSPORTCLASS_SPECIAL to make room for the jump
+);

--- a/hooks/Class4AttachSize.cpp
+++ b/hooks/Class4AttachSize.cpp
@@ -1,6 +1,6 @@
 asm(
     // Moho::CAiTransportImpl::"GetAttachPointsFor"+0xAA (switch case Moho::ETransportClass::TRANSPORTCLASS_4)  
     ".section h0; .set h0,0x5E6BDA;"
-    "jmp .+0x1F;" // add break to case so it doesn't fall-through and get overriden by TRANSPORTCLASS_SPECIAL
+    "jmp .+0x1F; nop;" // add break to case so it doesn't fall-through and get overriden by TRANSPORTCLASS_SPECIAL
     // by utilizing output assignment of case TRANSPORTCLASS_3/TRANSPORTCLASS_SPECIAL to make room for the jump
 );


### PR DESCRIPTION
The engine is missing a break in a switch-case statement that makes class 4 attach points get overridden by class special attach points by fall-through - this PR adds the break.