### PR TITLE
Some Fixes

### DIFF
--- a/section/SetStatFix.cpp
+++ b/section/SetStatFix.cpp
@@ -1,31 +1,26 @@
 #include "include/moho.h"
 
-void PushTrue()
-{
-    register lua_State *l asm("eax");
-    lua_pushboolean(l, true);
-}
-
-void SetStatCheck()
-{
-    asm(
-        // mov    ebx, eax //pointer to our stat in other thread
-        "mov     eax, [edi];" // pointer to lua state
-        "cmp ebx, 0;"
-        "je SetStatCheck_invalid;" // go to return 1
-        "mov     esi, 3;"
-        "jmp 0x6CCA31;" // get back into normal function flow
-        "SetStatCheck_invalid:"
-        "call %[PushTrue];"
-        "mov eax, 1;"
-        "pop     edi;"
-        "pop     esi;"
-        "pop     ebx;"
-        "mov     esp, ebp;"
-        "pop     ebp;"
-        "ret;"
-        :
-        : [PushTrue] "i"(PushTrue)
-        :
-        );
+void SetStatCheck() {
+  asm(
+      // mov    ebx, eax //pointer to our stat in other thread
+      "mov     eax, [edi];" // pointer to lua state
+      "cmp ebx, 0;"
+      "je SetStatCheck_invalid;" // go to return 1
+      "mov     esi, 3;"
+      "jmp 0x6CCA31;" // get back into normal function flow
+      "SetStatCheck_invalid:"
+      "push 1;"
+      "push eax;"
+      "call 0x90cf80;" //pushbool
+      "add esp, 8;"
+      "mov eax, 1;"
+      "pop     edi;"
+      "pop     esi;"
+      "pop     ebx;"
+      "mov     esp, ebp;"
+      "pop     ebp;"
+      "ret;"
+      :
+      :
+      :);
 }

--- a/section/SetStatFix.cpp
+++ b/section/SetStatFix.cpp
@@ -1,5 +1,3 @@
-#include "include/moho.h"
-
 void SetStatCheck() {
   asm(
       // mov    ebx, eax //pointer to our stat in other thread

--- a/section/include/global.h
+++ b/section/include/global.h
@@ -124,6 +124,12 @@ struct basic_string {
   const T* data() {
     return size < sso_size ? &str : *(const T**)str;
   }
+   ~basic_string() {
+    if (size < sso_size) {
+      return;
+    }
+    free(*(const T **)str);
+  }
 };
 
 VALIDATE_SIZE(string, 0x1C)

--- a/section/include/global.h
+++ b/section/include/global.h
@@ -39,18 +39,18 @@ GDecl(range_RenderBuild,		0x10A6414, bool)
 GDecl(d3d_WindowsCursor,		0x10A636E, bool)
 GDecl(debugSelect,			0x10A645E, bool)
 
-GDecl(s_FACTORY,			0xE19824, const char*)
-GDecl(s_EXPERIMENTAL,			0xE204B8, const char*)
-GDecl(s_ExpectedButGot,			0xE0A220, const char*) // "%s\n  expected %d args, but got %d"
-GDecl(s_ExpectedBetweenButGot,		0xE0A270, const char*) // "%s\n  expected between %d and %d args, but got %d"
-GDecl(s_Global,				0xE00D90, const char*) // "<global>"
-GDecl(s_CMauiBitmap,			0xE37438, const char*) // "CMauiBitmap"
-GDecl(s_UserUnit,			0xE4D090, const char*) // "UserUnit"
-GDecl(s_ExpectedAGameObject,		0xE09860, const char*) // "Expected a game object. (Did you call with '.' instead of ':'?)"
-GDecl(s_GameObjectHasBeenDestroyed,	0xE098A0, const char*) // "Game object has been destroyed"
-GDecl(s_IncorrectTypeOfGameObject,	0xE098C0, const char*) // "Incorrect type of game object.  (Did you call with '.' instead of ':'?)"
-GDecl(s_UnknownColor,			0x4B2D54, const char*) // "Unknown color: %s"
-GDecl(s_c_object,			0xE016DC, const char*) // "_c_object"
+extern const char s_FACTORY[]		asm("0xE19824");
+extern const char s_EXPERIMENTAL[]		asm("0xE204B8");
+extern const char s_ExpectedButGot[]		asm("0xE0A220"); // "%s\n  expected %d args, but got %d"
+extern const char s_ExpectedBetweenButGot[]	asm("0xE0A270"); // "%s\n  expected between %d and %d args, but got %d"
+extern const char s_Global[]			asm("0xE00D90"); // "<global>"
+extern const char s_CMauiBitmap[]		asm("0xE37438"); // "CMauiBitmap"
+extern const char s_UserUnit[]		asm("0xE4D090"); // "UserUnit"
+extern const char s_ExpectedAGameObject[]	asm("0xE09860"); // "Expected a game object. (Did you call with '.' instead of ':'?)"
+extern const char s_GameObjectHasBeenDestroyed[]asm("0xE098A0"); // "Game object has been destroyed"
+extern const char s_IncorrectTypeOfGameObject[]asm("0xE098C0"); // "Incorrect type of game object.  (Did you call with '.' instead of ':'?)"
+extern const char s_UnknownColor[]		asm("0xE07D14"); // "Unknown color: %s"
+extern const char s_c_object[]		asm("0xE016DC"); // "_c_object"
 
 GDecl(g_ExeVersion1,			0x876666, const int)
 GDecl(g_ExeVersion2,			0x87612d, const int)

--- a/section/include/global.h
+++ b/section/include/global.h
@@ -107,10 +107,7 @@ struct basic_string {
   uint32_t size; // capacity?
 
   basic_string() {
-    ptr = 0;
-    str[0] = T(0);
-    strLen = 0;
-    size = 0;
+    _clear();
   }
 
   basic_string(const char*s) {
@@ -124,11 +121,22 @@ struct basic_string {
   const T* data() {
     return size < sso_size ? &str : *(const T**)str;
   }
+
    ~basic_string() {
     if (size < sso_size) {
       return;
     }
     free(*(const T **)str);
+    _clear();
+  }
+
+private:
+  void _clear()
+  {
+    ptr = 0;
+    str[0] = T(0);
+    strLen = 0;
+    size = 0;
   }
 };
 

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -1475,7 +1475,7 @@ struct VMatrix4
 VALIDATE_SIZE(VMatrix4, 0x40);
 
 
-struct CD3DPrimBarcher //0x007F6BD0 292 bytes
+struct CD3DPrimBatcher //0x007F6BD0 292 bytes
 {
 void* textureBatcher;
 int pad1[22];
@@ -1489,4 +1489,4 @@ bool padb2;
 int unk;
 };
 
-VALIDATE_SIZE(CD3DPrimBarcher, 292);
+VALIDATE_SIZE(CD3DPrimBatcher, 292);

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -194,10 +194,36 @@ struct Camera // : RCamCamera
 {//0x007A7972, 0x858 bytes
 };
 
-struct CMauiControl : CScriptObject
+struct CMauiControl : CScriptObject //ctor 0x007867B0
 {//0x004C6F8A, 0x11C bytes
 	using Type = ObjectType<0x10C7700, 0xF83314>;
+
+	void *unk1;
+	void *unk2;
+	CMauiControl *parent;
+	void *unk3;
+	void *unk4;
+	LuaObject left;
+	LuaObject right;
+	LuaObject top;
+	LuaObject bottom;
+	LuaObject width;
+	LuaObject height;
+	LuaObject depth;
+	float f_depth;
+	void *field_D8;
+	void *field_DC;
+	void *field_E0;
+	void *field_E4;
+	bool flags[8];
+	float field_F0;
+	int unk5;
+	void *unk6;
+	void *unk7;
+	string name;
 };
+VALIDATE_SIZE(CMauiControl, 0x11C)
+
 
 struct CWldSession;
 

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -1467,3 +1467,26 @@ namespace incomplete {
 		Vector3f pos; // at 0x64
 	};
 }
+
+struct VMatrix4
+{
+	float data[16];
+};
+VALIDATE_SIZE(VMatrix4, 0x40);
+
+
+struct CD3DPrimBarcher //0x007F6BD0 292 bytes
+{
+void* textureBatcher;
+int pad1[22];
+VMatrix4 viewMatrix;//4x23
+VMatrix4 projectionMatrix;//4x39
+VMatrix4 unknownMatrix;//4x55
+bool b1;
+bool b2;
+bool padb1;
+bool padb2;
+int unk;
+};
+
+VALIDATE_SIZE(CD3DPrimBarcher, 292);

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -1560,8 +1560,7 @@ class vector_inline
 
 struct moho_entity_set
 {
-	moho_entity_set *unk1;
-	moho_entity_set *unk2;
+	linked_list<moho_entity_set> unk;
 	vector_inline<Entity*, 2> data;
 };
 VALIDATE_SIZE(moho_entity_set, 0x20);

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -1488,5 +1488,49 @@ bool padb1;
 bool padb2;
 int unk;
 };
-
 VALIDATE_SIZE(CD3DPrimBatcher, 292);
+
+
+struct Quaternion
+{
+	float x,y,z,w;
+};
+
+struct  VTransform
+{
+Quaternion orientation;
+Vector3f pos;
+};
+
+
+struct GeomSolid
+{
+	float data[4];
+};
+
+
+struct GeomCamera // sizeof=0x2C4
+{
+    VTransform transform;
+    VMatrix4 projectionMatrix;
+    VMatrix4 viewMatrix;
+    VMatrix4 viewProjMatrix;
+    VMatrix4 inverseProjMatrix;
+    VMatrix4 inverseViewMatrix;
+    VMatrix4 inverseViewProjMatrix;
+    void *ptr1;//??
+    void *ptr2;
+    void *ptr3;
+    void *ptr4;
+    void *ptr5;
+    float unk1[24];
+    void *ptr6;
+    void *ptr7;
+    void *ptr8;
+    void *ptr9;
+    float unk2[24];
+    float unk_float1;
+    float unk3[16];
+};
+
+VALIDATE_SIZE(GeomCamera, 708);

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -983,10 +983,27 @@ struct CPlatoon : public CScriptObject
 	using Type = ObjectType<0x10C6FCC, 0xF6A1FC>;
 };
 
-struct CMauiBitmap : public CMauiControl
+struct CMauiBitmap : public CMauiControl //ctor 0x0077F950 
 {
 	using Type = ObjectType<0x10C7704, 0xF832F4>;
+
+	void *field_11C;
+	void *field_120;
+	void *field_124;
+	void *field_128;
+	LuaObject bitmapWidth;
+	LuaObject bitmapHeight;
+	void *field_154;
+	void *field_158;
+	float field_15C;
+	float field_160;
+	void *field_164;
+	bool field_168[4];
+	float field_16C;
+	bool field_170[4];
+	void *unk_[6];
 };
+VALIDATE_SIZE(CMauiBitmap, 0x18C)
 
 struct ReconBlip : Entity
 {	// 0x4D0 bytes

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -1140,23 +1140,26 @@ struct CSimDriver // : ISTIDriver
 };
 VALIDATE_SIZE(CSimDriver, 0x230);
 
-struct CHeightField // : class detail::boost::sp_counted_base
-{//0x00579121, 0x10 bytes
-	void* vtable;
-};
-
-struct MapData
+struct CHeightField //ctor 0x00476090 
 {	// 0x1C bytes
-	uint32_t *TerrainHeights; // Word(TerrainHeights+(Y*SizeX+X)*2)
+	uint16_t *data; // 
 	int SizeX; // +1
 	int SizeY; // +1
+	void* unk1;
+	void* unk2;
+	void* unk3;
+	void* unk4;
 };
+VALIDATE_SIZE(CHeightField, 0x1C);
 
-struct STIMap
+struct STIMap //ctor 0x00577890
 {	// 0x1548 bytes
-	MapData *MapData;
-	CHeightField *HeightField;
-	uint32_t unk1[4];
+	CHeightField*HeightField;
+	void* unk_1;
+	void* unk_2;
+	void* unk_3;
+	int SizeX; // +1
+	int SizeY; // +1
 	// at 0x18
 	void *beginData;
 	void *endData;
@@ -1165,8 +1168,8 @@ struct STIMap
 	// at 0x28
 	LuaObject Data[0x100]; // Type desc tables
 	uint8_t *TerrainTypes; // TerrainTypes+(Y*SizeX+X)
-	int SizeX;
-	int SizeY;
+	int SizeX1;
+	int SizeY1;
 	uint8_t unk2[0x100];
 	// at 0x1534
 	BOOL Water;
@@ -1534,3 +1537,4 @@ struct GeomCamera // sizeof=0x2C4
 };
 
 VALIDATE_SIZE(GeomCamera, 708);
+

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -1479,9 +1479,9 @@ struct CD3DPrimBarcher //0x007F6BD0 292 bytes
 {
 void* textureBatcher;
 int pad1[22];
-VMatrix4 viewMatrix;//4x23
-VMatrix4 projectionMatrix;//4x39
-VMatrix4 unknownMatrix;//4x55
+VMatrix4 viewMatrix;
+VMatrix4 projectionMatrix;
+VMatrix4 unknownMatrix;
 bool b1;
 bool b2;
 bool padb1;

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -1551,17 +1551,38 @@ Vector3f pos;
 template<class T, int I>
 class vector_inline
 {
+public:
   T *begin;
   T *end;
   T *capacity_end;
   T *inline_begin;
-  T vector[I];
+  T inlined_items[I];
 };
 
 struct moho_entity_set
 {
+	moho_entity_set()
+	{
+		unk.prev = this;
+		unk.next = this;
+		data.begin = &data.inlined_items[0];
+		data.end = &data.inlined_items[0];
+		data.capacity_end = &data.inlined_items[2];
+		data.inline_begin = &data.inlined_items[0];
+	}
+
+
 	linked_list<moho_entity_set> unk;
 	vector_inline<Entity*, 2> data;
+
+	~moho_entity_set()
+	{
+		if ( data.begin != data.inline_begin )
+			free(data.begin);
+			
+		unk.next->unk.prev = unk.prev;
+		unk.prev->unk.next = unk.next;
+	}
 };
 VALIDATE_SIZE(moho_entity_set, 0x20);
 

--- a/section/include/moho.h
+++ b/section/include/moho.h
@@ -1548,36 +1548,49 @@ Quaternion orientation;
 Vector3f pos;
 };
 
-
-struct GeomSolid
+template<class T, int I>
+class vector_inline
 {
-	float data[4];
+  T *begin;
+  T *end;
+  T *capacity_end;
+  T *inline_begin;
+  T vector[I];
 };
 
-
-struct GeomCamera // sizeof=0x2C4
+struct moho_entity_set
 {
-    VTransform transform;
-    VMatrix4 projectionMatrix;
-    VMatrix4 viewMatrix;
-    VMatrix4 viewProjMatrix;
-    VMatrix4 inverseProjMatrix;
-    VMatrix4 inverseViewMatrix;
-    VMatrix4 inverseViewProjMatrix;
-    void *ptr1;//??
-    void *ptr2;
-    void *ptr3;
-    void *ptr4;
-    void *ptr5;
-    float unk1[24];
-    void *ptr6;
-    void *ptr7;
-    void *ptr8;
-    void *ptr9;
-    float unk2[24];
-    float unk_float1;
-    float unk3[16];
+	moho_entity_set *unk1;
+	moho_entity_set *unk2;
+	vector_inline<Entity*, 2> data;
+};
+VALIDATE_SIZE(moho_entity_set, 0x20);
+
+struct Plane3f
+{
+  Vector3f Normal;
+  float Constant;
 };
 
-VALIDATE_SIZE(GeomCamera, 708);
+struct CGeomSolid3
+{  
+  vector_inline<Plane3f, 6> planes;
+};  
 
+struct CGeomCamera3
+{
+  VTransform transform;
+  VMatrix4 projection;
+  VMatrix4 view;
+  VMatrix4 viewProjection;
+  VMatrix4 inverseProjection;
+  VMatrix4 inverseView;
+  VMatrix4 inverseViewProjection;
+  int prolly_alignment;
+  CGeomSolid3 solid1;
+  CGeomSolid3 solid2;
+  float lodScale;
+  VMatrix4 viewport;
+};
+
+VALIDATE_SIZE(CGeomCamera3, 708);


### PR DESCRIPTION
* Add string dtor. Before that calling `CopyToClipboard` with long strings was causing memory leak;
* Fix for `SetStat` is now pure asm;
* Proper engine string declaration. Before that they were declared as pointers and implying that could be changed. Now they are of array type;
* Proper address for string `s_UnknownColor`.
* Add definition for `VMatrix4` ,`CD3DPrimBatcher` and `GeomCamera`
* fix definitions of `CHeightField`, `STIMap`, CMauiControl and CMauiBitmap