### PR TITLE
Add the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) FAForever
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
A license is healthy to have in general, but specifically we'd like to add a license to the repository so that the content can be re-used in other places. One example is the project of @4z0t . See also:

- https://github.com/4z0t/SCFA-python-patcher

As discussed on [Discord](https://discord.com/channels/197033481883222026/1270400016804220970).

In order to do this we need to acknowledgement of all existing contributors that they are fine with their work being licensed in the MIT license. This includes:

- [x] @KionX 
- [x] @4z0t 
- [x] @Hdt80bro 
- [x] @Sheikah45 
- [x] @Garanas 
- [x] @Strogoo 
- [x] @RutreD

Please acknowledge that you accept or decline the introduction of a license.