### PR TITLE
Add destructor for `basic_string` implementation

### DIFF
--- a/section/include/global.h
+++ b/section/include/global.h
@@ -124,6 +124,18 @@ struct basic_string {
   const T* data() {
     return size < sso_size ? &str : *(const T**)str;
   }
+
+  ~basic_string()
+  {
+    if(size >= sso_size)
+    {
+      free(data());
+    }
+    ptr = 0;
+    str[0] = T(0);
+    strLen = 0;
+    size = sso_size - 1;
+  }
 };
 
 VALIDATE_SIZE(string, 0x1C)


### PR DESCRIPTION
Based on dtor of `string` (0x00402370) and `wstring` (0x00431390).