### PR TITLE
Replace `LuaObject::Insert` with `LuaObject::SetObject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ These don't matter except for other assembly patches
     - hooks/CameraPerf.cpp
 - Optimised some AI actions
     - hooks/aiinitattack.cpp
-- Optimized lua tables filling
+- Reduce overhead of population of Lua tables in C code. Affected functions:
+    * UI
+      * EntityCategoryFilterOut
+      * EntityCategoryFilterDown
+      * SelectUnits
+    * Sim
+      * EntityCategoryFilterDown
     - hooks/TableInsertFix.cpp
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ These don't matter except for other assembly patches
     - hooks/CameraPerf.cpp
 - Optimised some AI actions
     - hooks/aiinitattack.cpp
+- Optimized lua tables filling
+    - hooks/TableInsertFix.cpp
 
 ## Bugs
 - Remove lingering transport load factor calcuation at aircraft initialization
@@ -120,7 +122,7 @@ These don't matter except for other assembly patches
     - hooks/OnMotionTurnEvent.cpp
 
 ## Additions
-These new features have been added in a backwards compatibile manner
+These new features have been added in a backwards compatible manner
 
 - Enable unused console commands: ren_Steering, dbg_Ballistics, dbg_EfxBeams, dbg_Trail, dbg_CollisionBeam, dbg_Projectile
     - hooks/EnableConsoleCommands.cpp

--- a/hooks/TableInsertFix.cpp
+++ b/hooks/TableInsertFix.cpp
@@ -1,0 +1,17 @@
+
+//Replaces Insert with set table
+asm(
+    ".section h0; .set h0,0x008BA4A9;" // at EntityCategoryFilterOut UI
+    "call 0x009087A0;" // Call LuaObject::SetObject(int index, LuaObject& obj)
+    ".section h1; .set h1,0x008BA177;" // at EntityCategoryFilterDown UI
+    "call 0x009087A0;"// Call LuaObject::SetObject(int index, LuaObject& obj)
+    ".section h2; .set h2,0x008BDB60;" // at SelectUnits
+    "call 0x009087A0;"// Call LuaObject::SetObject(int index, LuaObject& obj)
+    ".section h3; .set h3,0x00759E53;" // at EntityCategoryFilterDown Sim
+    "call 0x009087A0;"// Call LuaObject::SetObject(int index, LuaObject& obj)
+);
+
+// Testing commands
+// UI_Lua local _ti = table.insert local i = 1 local s = GetSelectedUnits() or {} _G.table.insert = function(...) LOG(i) i = i + 1 return _ti(unpack(arg)) end EntityCategoryFilterDown(categories.COMMAND,s) _G.table.insert = _ti
+// UI_Lua local _ti = table.insert local i = 1 local s = GetSelectedUnits() or {} _G.table.insert = function(...) LOG(i) i = i + 1 return _ti(unpack(arg)) end EntityCategoryFilterOut(categories.COMMAND,s) _G.table.insert = _ti
+


### PR DESCRIPTION
Replaces `LuaObject::Insert` with `LuaObject::SetObject`. `LuaObject::Insert` implementation uses global access to `table.insert`, which can be very expensive, in addition it does this every time. `LuaObject::SetObject` is equivalent to `t[n] = o` syntax. 

## Testing
```
UI_Lua local _ti = table.insert local i = 1 local s =  GetSelectedUnits() or {} _G.table.insert = function(... )  LOG(i) i = i + 1 return  _ti(unpack(arg)) end  EntityCategoryFilterDown(categories.COMMAND,s)  _G.table.insert = _ti
UI_Lua local _ti = table.insert local i = 1 local s =  GetSelectedUnits() or {} _G.table.insert = function(... )  LOG(i) i = i + 1 return  _ti(unpack(arg)) end  EntityCategoryFilterOut(categories.COMMAND,s)  _G.table.insert = _ti
```
These commands before patch will produce logging into console when units selected. After patch no console output is expected.