### PR TITLE
Mass extractor template snapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ These don't matter except for other assembly patches
     - hooks/WallSelection.cpp
 - Make `LOWSELECTPRIO` apply to units under construction
     - hooks/selectionPriority.cpp
+- Allow mass extractor template snapping
+    - hooks/BuildTemplateSnap.cpp
+    - section/BuildTemplateSnap.cpp
 
 ## Lua
 - Change `SUBCOMMANDER` category name to `SACU_BEHAVIOR` (FAF makes this transparent)

--- a/hooks/BuildTemplateSnap.cpp
+++ b/hooks/BuildTemplateSnap.cpp
@@ -1,0 +1,11 @@
+
+asm(
+    // Nop check for empty template data
+    ".section h0; .set h0,0x0086FFF0;"
+    "NOP;"
+    "NOP;"
+    "NOP;"
+    "NOP;"
+    "NOP;"
+    "NOP;"
+);

--- a/hooks/BuildTemplateSnap.cpp
+++ b/hooks/BuildTemplateSnap.cpp
@@ -1,11 +1,18 @@
+#define SECTION(index, address) ".section h"#index"; .set h"#index","#address";"
+#include "../define.h"
 
 asm(
-    // Nop check for empty template data
-    ".section h0; .set h0,0x0086FFF0;"
+    SECTION(0, 0x0086FFF0)
     "NOP;"
     "NOP;"
     "NOP;"
     "NOP;"
     "NOP;"
     "NOP;"
+    SECTION(1, 0x00870044)
+    "jmp "QU(HookHydroCondition)";"
+    "nop;"
+    "nop;"
+    "nop;"
+    "nop;"
 );

--- a/section/BuildTemplateSnap.cpp
+++ b/section/BuildTemplateSnap.cpp
@@ -1,0 +1,24 @@
+void HookHydroCondition()
+{
+    asm(
+        "sub     eax, 1;" // check if hydro
+        "jnz 0x008701E1;" // not hydro, jump out
+        // Check if we have any templates
+        "mov     ecx, [esp+0x260];" // build_template.finish
+        "sub     ecx, [esp+0x25C];" // build_template.start
+        "mov     eax, 0x2E8BA2E9;"
+        "imul    ecx;"
+        "sar     edx, 3;"
+        "mov     eax, edx;"
+        "shr     eax, 0x1F;"
+        "add     eax, edx;"
+        // end
+        "jnz 0x008701E1;"
+        // snap hydro
+        "mov ecx, [esp+0x1E4];" // comDat.blueprint
+        "xor eax, eax;"
+        "jmp 0x0087004D;"
+        :
+        :
+        :);
+}


### PR DESCRIPTION
Removes check of active build templates to allow snapping to resouce locations. Corresponding issue: https://github.com/FAForever/FA-Binary-Patches/issues/28 .
Template snapping applies only for mass extractors. Buildmode must start with mass extractor in order to snap.
Testing:
Create template **starting** with mass extractor. It must properly snap to mass locations.
![template_snapping](https://github.com/user-attachments/assets/a6eaaa7e-2105-4f41-89f3-8929aae1fe41)

Note: if you create template that isn't started with mass extractor it won't snap
![template_snapping2](https://github.com/user-attachments/assets/744e2b9a-abb5-47d5-8763-a5bd6bad7d1f)

As said: hydrocarbon templates don't snap, but hydro itself does.
![template_snapping3](https://github.com/user-attachments/assets/3389cc7f-1743-453f-830f-b618514b29a4)

