### PR TITLE
Fix `SiloGiveAmmo` extension

### DIFF
--- a/section/GiveNukeSiloAmmo.cpp
+++ b/section/GiveNukeSiloAmmo.cpp
@@ -35,7 +35,8 @@ void SiloAmmoSetBlocks()
     asm(
         "cmp %[Blocks], 0;"
         "je Finish;"
-        "mov [ebx+0x48], eax;" //here we set the number of blocks. This value is used by Moho::CAiSiloBuildImpl::SiloTick for calculations
+        "cvtsi2ss xmm0, eax;" //here we set the number of blocks. This value is used by Moho::CAiSiloBuildImpl::SiloTick for calculations
+        "movss ds:[ebx+0x48], xmm0;"
         "jmp 0x6CEDFA;"
 
         //default code


### PR DESCRIPTION
https://github.com/FAForever/FA-Binary-Patches/pull/92 introduced fix for silos that made them more viable with no resources in storages. However there was a fix that allowed to set progress to silo. And it was missed change. This PR makes this change (But in future there will be proper way to set it with C++). For now it only requires this change.

## Testing

* Launch a game with ally AI and cheats
* Load a nuke to some progress
* Give to AI
* Builing progress must be set
