### PR TITLE
Remove stack frame of some math funcs

### DIFF
--- a/hooks/math.hook
+++ b/hooks/math.hook
@@ -1,0 +1,31 @@
+0x00452FC0: // sqrt
+    fld dword ptr [esp+4]
+    fsqrt
+    ret
+0x0040EAF0: // sqrt
+    fld dword ptr [esp+4]
+    fsqrt
+    ret
+0x0050D150: // inverse sqrt
+    fld dword ptr [esp+4]
+    fsqrt
+    fld1
+    fdivrp st(1), st
+    ret
+0x005734E0: // sin
+    fld dword ptr [esp+4]
+    fsin
+    ret
+0x005734D0: // cos
+    fld dword ptr [esp+4]
+    fcos 
+    ret
+0x0040DAB0: // abs
+    fld dword ptr [esp+4]
+    fabs
+    ret
+0x004E9DF0: // atan2
+    fld dword ptr [esp+4]
+    fld dword ptr [esp+8]
+    fpatan
+    ret


### PR DESCRIPTION
Removes `push ebp;  mov ebp, esp;` - ` mov esp, ebp; pop ebp;`.
Primarily serves as example of new hook format, since performance gain is negligible.