### PR TITLE
Adjustable LODCutoffs

### DIFF
--- a/hooks/BlueprintCheckAdditionalField.cpp
+++ b/hooks/BlueprintCheckAdditionalField.cpp
@@ -1,0 +1,15 @@
+#define SECTION(index, address) ".section h"#index"; .set h"#index","#address";"
+#include "../define.h"
+asm(
+    
+    SECTION(1, 0x004CF7F2)
+    "jmp "QU(GetBpFieldValues)";"
+    
+    SECTION(2, 0x004CF7F7)
+    "jmp "QU(ProcessBpFieldValues)";"
+    "nop;"
+    
+    SECTION(3, 0x005283D5)
+    "jmp "QU(InitRMeshBlueprint)";"
+    "nop;"
+);

--- a/hooks/LODProcessing.cpp
+++ b/hooks/LODProcessing.cpp
@@ -1,0 +1,28 @@
+#define SECTION(index, address) ".section h"#index"; .set h"#index","#address";"
+#include "../define.h"
+asm(
+    
+    SECTION(1, 0x005039F3)
+    "jmp "QU(FirstLODCheck)";"   //initial max LODCutoff check
+    "nop;"
+    
+    SECTION(2, 0x007DDA73)
+    "jmp "QU(MeshComputeLOD)";"  //part of Moho::Mesh::ComputeLOD
+    
+    SECTION(3, 0x007DDA83)
+    "jmp "QU(ProcessBestLOD)";"  //part of Moho::Mesh::ComputeLOD
+    
+    SECTION(4, 0x007DDA9B)
+    "jmp "QU(ProcessWorstLOD)";" //part of Moho::Mesh::ComputeLOD
+    "nop;"
+    "nop;"
+    "nop;"
+    
+    SECTION(5, 0x007DFC0C)
+    "movss xmm1, xmm7;"       //Taking our modified LODCutoff that we saved before in MeshComputeLOD
+    "nop;"                    
+
+    SECTION(6, 0x007DFC31)    //same
+    "movss xmm1, xmm7;"       
+    "nop;"
+);

--- a/hooks/LODProcessing.cpp
+++ b/hooks/LODProcessing.cpp
@@ -6,23 +6,14 @@ asm(
     "jmp "QU(FirstLODCheck)";"   //initial max LODCutoff check
     "nop;"
     
-    SECTION(2, 0x007DDA73)
-    "jmp "QU(MeshComputeLOD)";"  //part of Moho::Mesh::ComputeLOD
+    SECTION(2, 0x007DFBE6)
+    "call "QU(ComputeLOD)";"
     
-    SECTION(3, 0x007DDA83)
-    "jmp "QU(ProcessBestLOD)";"  //part of Moho::Mesh::ComputeLOD
-    
-    SECTION(4, 0x007DDA9B)
-    "jmp "QU(ProcessWorstLOD)";" //part of Moho::Mesh::ComputeLOD
-    "nop;"
-    "nop;"
-    "nop;"
-    
-    SECTION(5, 0x007DFC0C)
-    "movss xmm1, xmm7;"       //Taking our modified LODCutoff that we saved before in MeshComputeLOD
+    SECTION(3, 0x007DFC0C)
+    "movss xmm0, xmm7;"       //Taking our modified LODCutoff that we saved before in MeshComputeLOD
     "nop;"                    
 
-    SECTION(6, 0x007DFC31)    //same
-    "movss xmm1, xmm7;"       
+    SECTION(4, 0x007DFC31)    //same
+    "movss xmm0, xmm7;"       
     "nop;"
 );

--- a/section/BlueprintFieldCheck.cpp
+++ b/section/BlueprintFieldCheck.cpp
@@ -1,6 +1,7 @@
 #include "moho.h"
 
 const char *meshGroupField = "MeshGroupID";
+const char *isSmallObjectField = "IsSmallObject";
 
 char eaxStorage[4];
 char espStorage[4];
@@ -55,6 +56,14 @@ void ProcessBpFieldValues()
         }
     }
     
+    if (not strcmp(fieldName, isSmallObjectField))
+    {
+        if (bool(fieldValue)) //IsSmallObject = True
+        {
+            *(rBlueprint + 0x43) = true;
+        }
+    }
+    
     asm(
         //fixing registers
         "mov eax, %[eaxStorage];"
@@ -87,6 +96,7 @@ void InitRMeshBlueprint()
         
         //new clear mem
         "mov byte ptr [esi+0x42], 0x0;"
+        "mov byte ptr [esi+0x43], 0x0;"
         
         "jmp 0x005283DB;"
 	);

--- a/section/BlueprintFieldCheck.cpp
+++ b/section/BlueprintFieldCheck.cpp
@@ -1,7 +1,6 @@
 #include "moho.h"
 
-const char *meshGroupField = "MeshGroupID";
-const char *isSmallObjectField = "IsSmallObject";
+const char *meshGroupField = "LODGroup";
 
 char eaxStorage[4];
 char espStorage[4];
@@ -14,7 +13,7 @@ char *rBlueprint;
 
 
 //Blueprint loading on game start. We are inside Moho::SCR_LuaBuildObject (recursive function)
-//For now it is used for "MeshGroupID", but additional fields can be added in the future if needed.
+//For now it is used for "LODGroup", but additional fields can be added in the future if needed.
  
 void GetBpFieldValues()
 {
@@ -56,14 +55,6 @@ void ProcessBpFieldValues()
         }
     }
     
-    if (not strcmp(fieldName, isSmallObjectField))
-    {
-        if (bool(fieldValue)) //IsSmallObject = True
-        {
-            *(rBlueprint + 0x43) = true;
-        }
-    }
-    
     asm(
         //fixing registers
         "mov eax, %[eaxStorage];"
@@ -96,7 +87,6 @@ void InitRMeshBlueprint()
         
         //new clear mem
         "mov byte ptr [esi+0x42], 0x0;"
-        "mov byte ptr [esi+0x43], 0x0;"
         
         "jmp 0x005283DB;"
 	);

--- a/section/BlueprintFieldCheck.cpp
+++ b/section/BlueprintFieldCheck.cpp
@@ -1,0 +1,93 @@
+#include "moho.h"
+
+const char *meshGroupField = "MeshGroupID";
+
+char eaxStorage[4];
+char espStorage[4];
+char ebpStorage[4];
+char edxStorage[4];
+
+char *fieldName;
+float fieldValue;
+char *rBlueprint;
+
+
+//Blueprint loading on game start. We are inside Moho::SCR_LuaBuildObject (recursive function)
+//For now it is used for "MeshGroupID", but additional fields can be added in the future if needed.
+ 
+void GetBpFieldValues()
+{
+	asm(
+        "mov %[eaxStorage], eax;"
+        "mov %[espStorage], esp;"
+        "mov %[ebpStorage], ebp;"
+        "mov %[edxStorage], edx;"
+        
+        "mov %[fieldName], eax;"
+        
+        "mov ecx, dword ptr [ecx+0x58];"
+        "mov %[fieldValue], ecx;"
+        
+        "mov ecx, dword ptr [esp+0x4];"
+        "mov %[rBlueprint], ecx;"
+        
+        "jmp 0x004CF7F7;"
+        :
+        : [fieldName] "m" (fieldName),
+          [fieldValue] "m" (fieldValue),
+          [rBlueprint] "m" (rBlueprint),
+          [eaxStorage] "m" (eaxStorage),
+          [espStorage] "m" (espStorage),
+          [ebpStorage] "m" (ebpStorage),
+          [edxStorage] "m" (edxStorage)
+        :
+	);
+}
+
+void ProcessBpFieldValues()
+{
+    if (not strcmp(fieldName, meshGroupField)) //(not strcmp) == equal
+    {
+        if (fieldValue < 128)
+        {
+            int8_t groupID = int8_t(fieldValue);
+            *(rBlueprint + 0x42) = reinterpret_cast<int8_t>(groupID);
+        }
+    }
+    
+    asm(
+        //fixing registers
+        "mov eax, %[eaxStorage];"
+        "mov esp, %[espStorage];"
+        "mov ebp, %[ebpStorage];"
+        "mov edx, %[edxStorage];"
+
+        //default code
+        "mov ecx, dword ptr [esi+0x4];"
+        "mov ebp, eax;"
+        "push ebp;"
+        "CALL 0x008D94E0;" //gpg::RType::GetFieldNamed
+        "jmp 0x004CF7FD;"
+        
+        :
+        : [eaxStorage] "m" (eaxStorage),
+          [espStorage] "m" (espStorage),
+          [ebpStorage] "m" (ebpStorage),
+          [edxStorage] "m" (edxStorage)
+        :
+    );
+}
+
+void InitRMeshBlueprint()
+{
+	asm(
+        //default
+        "mov dword ptr ds:[esi+0x64], eax;"
+        "mov dword ptr ds:[esi+0x68], eax;"
+        
+        //new clear mem
+        "mov byte ptr [esi+0x42], 0x0;"
+        
+        "jmp 0x005283DB;"
+	);
+}

--- a/section/LODProcessing.cpp
+++ b/section/LODProcessing.cpp
@@ -1,0 +1,204 @@
+#include "moho.h"
+
+#define NON_GENERAL_REG(var_) [var_] "g"(var_)
+
+char LODMultTable[508]; //127*4
+bool applyToWorstOnly = false;
+
+
+void FirstLODCheck()
+{
+    //This is a first LOD check where engine compare max LODCuttof of an object with camera distance
+    //Then it prepares an array of visible objects to apply Moho::Mesh::ComputeLOD on them later
+    //Despite the fact that we are in Moho::MeshRenderer::Batch initial array contains not only meshes
+    //but also other things like effects/decals/etc
+    //So we have to check if we actually work with MeshInstance to prevent exceptions
+    //The normal route is MeshInstance->Mesh->RMeshBlueprint->GroupID(if exists)
+	asm(
+        //default
+        "movss xmm1, dword ptr ss:[esp+0x14];"
+        
+        
+        "push eax;"
+        "push ecx;"
+        "mov eax, dword ptr [esi+0x30];"  //Potential MeshInstance. esi+0x2C = max LODCuttof 
+        "mov ecx, dword ptr [eax+0x1C];"
+        "cmp ecx, 0xFFFFFFFF;"           
+        "jne Exit;"                       //Not a MeshInstance
+        
+        "mov eax, dword ptr [eax+0x14];"  //Mesh
+        "mov eax, dword ptr [eax+0x20];"  //RMeshBlueprint
+        "mov ecx, 0x00000000;"
+        "mov cl, byte ptr [eax+0x42];"
+        "cmp cl, 0x0;"                     
+        "je Exit;"                        //No groupId in mesh bp
+        
+        "mov al, 0x4;"
+        "mul cl;"
+        "mov ecx, %[LODMultTable];"
+        "add cx, ax;"
+        "mov eax, dword ptr[ecx];"
+        "cmp eax, 0;"
+        "je Exit;"                       //No mult
+        
+        "mulss xmm0, dword ptr[ecx];"
+        
+        "Exit:;"
+        "pop ecx;"
+        "pop eax;"
+        "jmp 0x005039F9;"
+        
+        :
+        : NON_GENERAL_REG(LODMultTable)
+        :
+	);
+}
+
+char savedMult[4];
+char null[4];
+
+void MeshComputeLOD()
+{
+    //Moho::Mesh::ComputeLOD
+    //this is where best LOD is picked from all avalaible
+    //ProcessBestLOD and ProcessWorstLOD are subparts of it
+	asm(
+        //default
+        "movss xmm0, dword ptr [eax+0x8];"
+        
+        "push eax;"
+        "push ebx;"
+        
+        "mov eax, 0x0;"
+        "mov %[savedMult], 0x0;"
+        "xorps xmm7, xmm7;"
+        "mov eax, dword ptr [esp+0x8];"
+        "mov eax, dword ptr [eax+0x20];"
+        "mov bl, byte ptr [eax+0x42];"
+        "cmp bl, 0x0;"
+        "je Exit2;"                      //No groupId
+        
+        "mov al, 0x4;"
+        "mul bl;"
+        "mov ebx, %[LODMultTable];"
+        "add bx, ax;"
+        "mov eax, dword ptr[ebx];"
+        "cmp eax, 0;"
+        "je Exit2;"                      //No mult
+        
+        "mov ebx, dword ptr[ebx];"
+        "mov %[savedMult], eax;"
+        
+        "Exit2:;"
+        "pop ebx;"
+        "pop eax;"
+        
+        "comiss xmm0, xmm2;"
+        "jbe RETURN1;"
+        
+        "jmp 0x007DDA7D;"
+        
+        "RETURN1:;"
+        "movss xmm7, xmm0;" //Save modified LODCuttof to xmm7 for futher use in some checks            
+        "pop esi;"
+        "ret;"
+        
+        :
+        : [applyToWorstOnly]"m"(applyToWorstOnly),
+          NON_GENERAL_REG(LODMultTable),
+          [savedMult]"m"(savedMult),
+          [null]"m"(null)
+        :
+	);
+}
+
+void ProcessBestLOD()
+{
+    asm(
+        "push eax;"
+        "mov al, %[applyToWorstOnly];"
+        "cmp al, 0x1;"
+        "je Exit3;"
+        
+        "mov eax, %[savedMult];"
+        "cmp eax, 0x0;"
+        "je Exit3;"
+        
+        "mulss xmm0, %[savedMult];"
+        
+        
+        "Exit3:;"
+        "pop eax;"
+        
+        //default
+        "comiss xmm1, xmm0;"
+        "jbe RETURN1;"
+        
+        "jmp 0x007DDA88;"
+        
+        :
+        : [applyToWorstOnly]"m"(applyToWorstOnly),
+          [savedMult]"m"(savedMult)
+        :
+    );
+}
+
+void ProcessWorstLOD()
+{
+    asm(
+        //default
+        "addss xmm0, dword ptr ds:[0x00F57F00];"
+        
+        "push eax;"
+        "mov eax, %[savedMult];"
+        "cmp eax, 0x0;"
+        "je Exit4;"
+        "mulss xmm0, %[savedMult];"
+        
+        "Exit4:;"
+        "pop eax;"
+        "comiss xmm1, xmm0;"
+        "jbe RETURN1;"
+        
+        //default
+        "xor eax, eax;"
+        "pop esi;"
+        "ret;"
+
+        :
+        : [savedMult]"m"(savedMult)
+        :
+    );
+}
+
+int LuaSetLODMult(lua_State *l)
+{
+    int groupID = luaL_checknumber(l, 1);
+    if  (groupID < 1 || groupID > 127)
+    {
+        luaL_error(l, "groupID should be from 1 to 127");
+        return 0;
+    }
+    float mult = luaL_optnumber(l, 2, 0);
+    
+    unsigned char *ch = reinterpret_cast<unsigned char *>(&mult);
+    
+    for (int i = 0; i != 5; ++i)
+    {
+        LODMultTable[4*groupID + i] = ch[i];
+    }
+
+    return 0;
+}
+
+UIRegFunc SetGroupLODMult{"SetGroupLODMult", "SetGroupLODMult(group:int, mult:float)", LuaSetLODMult};
+
+
+int LuaApplyMultToWorstLOD(lua_State *l)
+{
+    applyToWorstOnly = lua_toboolean(l, 1);
+    
+    return 0;
+}
+
+UIRegFunc ApplyMultToWorstLOD{"ApplyMultToWorstLODOnly", "ApplyMultToWorstLODOnly(apply:bool)", LuaApplyMultToWorstLOD};

--- a/section/LODProcessing.cpp
+++ b/section/LODProcessing.cpp
@@ -28,6 +28,9 @@ void FirstLODCheck()
         
         "mov eax, dword ptr [eax+0x14];"  //Mesh
         "mov eax, dword ptr [eax+0x20];"  //RMeshBlueprint
+        "cmp eax, 0x0;"
+        "je Exit;"                        //No MeshBP (projectiles don't have it for some reason)
+        
         "mov ecx, 0x00000000;"
         "mov cl, byte ptr [eax+0x42];"
         "cmp cl, 0x0;"                     
@@ -74,6 +77,9 @@ void MeshComputeLOD()
         "xorps xmm7, xmm7;"
         "mov eax, dword ptr [esp+0x8];"
         "mov eax, dword ptr [eax+0x20];"
+        "cmp eax, 0x0;"  
+        "je Exit2;"        
+        
         "mov bl, byte ptr [eax+0x42];"
         "cmp bl, 0x0;"
         "je Exit2;"                      //No groupId


### PR DESCRIPTION
Added 2 functions to UI:

```Python
SetGroupLODMult(int groupID, float multiplier)

ApplyMultToWorstLODOnly(true/false)
```

`MeshGroupID` should be added to Mesh blueprint (directly or via blueprints.lua). ID should be from 1 to 127. Then using `SetGroupLODMult` you can change LODCutoffs of given group on the fly.

![изображение](https://github.com/user-attachments/assets/68a49b48-f022-4305-99d1-a25779f113f2)


`ApplyMultToWorstLODOnly()` is set to False by default. This means multiplier will be applied to all avaliable LODs (LOD0, LOD1 etc). When `True` - only worst LOD is affected. For example:
```
                   Default LODs:     LOD0 = 50, LOD1 = 150.
Mult = 2, ApplytoWorst = true:     LOD0 = 50, LOD1 = 300
Mult = 2, ApplytoWorst = false:    LOD0 = 100, LOD1 = 300
```


One more UI function:

```Lua
SetSmallShadowCutoff(float distance)
```
Requires additional filed in mesh bp `IsSmallObject = true`.

![изображение](https://github.com/user-attachments/assets/aa63c65f-4106-4a02-9a18-fc83dc30b4cc)

`SetSmallShadowCutoff(distance)` default is 0 (means this check is disabled). Setting it to any number above `0` will disable shadows for small objects (IsSmallObject = true in mesh bp) at certain zoom level. Note that `distance` is not a `camera zoom` value, but a distance between current camera pos and an object. So it works similar to LODs, when objects at corners dissapear a bit earlier.

![shadows](https://github.com/user-attachments/assets/f6ac3c3b-42c3-45d8-9f9b-775418e89922)

