### PR TITLE
Unit:ForceReverseMove

### DIFF
--- a/hooks/EntityGetFootprint.hook
+++ b/hooks/EntityGetFootprint.hook
@@ -1,8 +1,3 @@
-//Moho::SSTIEntityVariableData::SSTIEntityVariableData
-0x00558823:
-    mov dword ptr [eax+0x0A4], ecx // 0x0A5 bool forceAltFootprint
-
-
 //  Moho::Entity::GetFootprint
 0x006788A5:
     jmp @asm__GetFootprint

--- a/hooks/MohoEntityVariableData.hook
+++ b/hooks/MohoEntityVariableData.hook
@@ -1,0 +1,5 @@
+//Moho::SSTIEntityVariableData::SSTIEntityVariableData
+0x00558823:
+    mov dword ptr [eax+0x0A4], ecx // 0x0A5 bool forceAltFootprint
+                                   // 0x0A6 bool isForceReclaim
+                                   // 0x0A7 bool isForceReverseMove

--- a/hooks/UnitForceReverseMove.hook
+++ b/hooks/UnitForceReverseMove.hook
@@ -1,0 +1,14 @@
+0x005B34FB:
+    jmp @asm__UnitForceReverseCheck
+    nop
+    nop
+    nop
+    nop
+
+0x005B3578:
+    jmp @asm__BackUpDistanceCheck
+    
+0x005B3566:
+    jmp @asm__MovementTypeIDCheck
+    nop
+    nop

--- a/section/UnitForceReverseMove.cpp
+++ b/section/UnitForceReverseMove.cpp
@@ -1,0 +1,79 @@
+#include "CObject.h"
+#include "magic_classes.h"
+#include "moho.h"
+
+// Any changes made here WILL NOT affect units without ForceReverseMove flag
+// Without this flag all movement calculations go through default route
+
+void asm__UnitForceReverseCheck()
+{
+	asm(
+        "movss xmm2, dword ptr ss:[esp+0x8C];" //default code
+        
+        "cmp byte ptr ss:[ebx+0x127], 0x1;"   //unit.forceReverseMove
+        
+        "jne 0x005B3504;"   // no ForceReverseMove, use default logic
+     
+        "jmp 0x005B354A;"   // otherwise jump straight to "reverse" case
+	);
+}
+
+
+// This called every few ticks (5-10?) until command is done
+void asm__BackUpDistanceCheck()
+{
+	asm(
+        "movss xmm0, dword ptr ds:[ecx+0x70];" //default code
+        
+        "cmp byte ptr ss:[ebx+0x127], 0x1;"   //unit.forceReverseMove
+        
+        "jne 0x005B357D;"                     //no ForceReverseMove, use default route to compare BackUpDistance
+
+        "jmp 0x005B3591;"                     //ignore all checks and go to "reverse"            
+	);
+}
+
+// When unit is in ForceReverseMove mode, movementTypeID should always be 5
+// When moving in formation using reverse move, some units randomly change it to normal move (id = 7)
+// and then after a few tick return to reverse again. So we have to check it here and set to 5 manually
+// for all units in ForceReverseMove mode. 
+void asm__MovementTypeIDCheck()
+{
+	asm(
+        "cmp byte ptr ss:[ebx+0x127], 0x1;"  //unit.forceReverseMove
+        "jne Exit;"                          //no ForceReverseMove, no need to change ID
+        
+        "mov eax, 0x5;"
+        "mov dword ptr ss:[esp+0x64], eax;"
+        
+        "Exit:;"   
+        "mov eax, dword ptr ss:[esp+0x64];"    // default code
+        "cmp eax, 5;"                          // 
+        "jmp 0x005B356D;"                            
+	);
+}
+
+
+int ForceReverseMove(lua_State *L)
+{
+
+    if (lua_gettop(L) != 2)
+        L->LuaState->Error(s_ExpectedButGot, __FUNCTION__, 2, lua_gettop(L));
+    auto res = GetCScriptObject<Unit>(L, 1);
+    if (res.IsFail())
+        L->LuaState->Error("%s", res.reason);
+
+    void *unit = res.object;
+    bool flag = lua_toboolean(L, 2);
+
+    GetField<bool>(unit, 8+0x11F) = flag; // bool forceReverseMove
+
+    return 0;
+}
+using UnitMethodReg = SimRegFuncT<0x00E2D550, 0x00F8D704>;
+
+UnitMethodReg ForceReverseMoveReg{
+    "ForceReverseMove",
+    "",
+    ForceReverseMove,
+    "Unit"};


### PR DESCRIPTION
Added sim `Unit:ForceReverseMove(true/false)`

It affects both: new move command and already existed one. BUT if unit has a command already and moves forward, then there will be delay (~5-10 ticks) before it switches to reverse. That's because of movement function update rate.

So, if we want it to be instant (or at least as fast as possible) it's better to remove existed move order in simCallback, then `Unit:ForceReverseMove(true)` and then add new move command via sim function.

*Feel free to suggest different namings :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Units can be toggled into a force-reverse movement mode via scripting.

* **Refactor**
  * Movement logic hooks reorganized and padded to integrate reverse-move checks while preserving default behavior when disabled.
  * Entity variable handling adjusted to centralize boolean flags related to footprint and movement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->