### PR TITLE
[WIP] Lighting

### DIFF
--- a/hooks/TerrainLightingMultiplier.cpp
+++ b/hooks/TerrainLightingMultiplier.cpp
@@ -1,0 +1,10 @@
+#define SECTION(index, address) ".section h"#index"; .set h"#index","#address";"
+#include "../define.h"
+asm(
+    
+    SECTION(1, 0x0080163F)
+    "jmp "QU(GetTerrainLighMult)";"
+    "nop;"
+    "nop;"
+    "nop;"
+);

--- a/hooks/TerrainLightingMultiplier.cpp
+++ b/hooks/TerrainLightingMultiplier.cpp
@@ -7,4 +7,12 @@ asm(
     "nop;"
     "nop;"
     "nop;"
+    
+    SECTION(2, 0x008016D9)
+    "jmp "QU(GetSunColor)";"
+    "nop;"
+    
+    SECTION(3, 0x00801673)
+    "jmp "QU(GetSunPosition)";"
+    "nop;"
 );

--- a/section/TerrainLightingMultiplier.cpp
+++ b/section/TerrainLightingMultiplier.cpp
@@ -1,0 +1,35 @@
+#include "moho.h"
+#define NON_GENERAL_REG(var_) [var_] "g"(var_)
+
+float TerrainLighMult = 0;
+
+
+void GetTerrainLighMult()
+{
+    asm(
+        "cmp %[TerrainLighMult], 0x0;"
+        "je Default;"
+        
+        "fld %[TerrainLighMult];"
+        "jmp 0x00801647;"
+        
+        "Default:;"
+        "fld dword ptr ds:[ecx+0x2D8];"
+        "jmp 0x00801647;"
+
+        :
+        : [TerrainLighMult] "m" (TerrainLighMult)
+        :
+    );
+}
+
+int LuaSetTerrainLightingMultiplier(lua_State *l)
+{
+    float mult = luaL_optnumber(l, 1, 0);
+    
+    TerrainLighMult = mult;
+
+    return 0;
+}
+
+UIRegFunc SetTerrainLightingMultiplierReg{"SetTerrainLightingMultiplier", "SetTerrainLightingMultiplier(mult:float)", LuaSetTerrainLightingMultiplier};

--- a/section/TerrainLightingMultiplier.cpp
+++ b/section/TerrainLightingMultiplier.cpp
@@ -3,6 +3,14 @@
 
 float TerrainLighMult = 0;
 
+float sunR = 0;
+float sunG = 0;
+float sunB = 0;
+
+float sunX = 0;
+float sunY = 0;
+float sunZ = 0;
+
 
 void GetTerrainLighMult()
 {
@@ -23,6 +31,93 @@ void GetTerrainLighMult()
     );
 }
 
+void GetSunColor()
+{
+    asm(
+        //default
+        "lea edx, ss:[esp+0x1C];" 
+        "push edx;"
+        "mov eax, dword ptr ss:[esp];"
+        
+        "cmp %[sunR], 0x0;"
+        "je Default_1;"
+        
+        "fld dword ptr %[sunR];"
+        "fstp dword ptr ds:[eax];"
+        "fld dword ptr %[sunG];"
+        "fstp dword ptr ds:[eax+0x4];"
+        "fld dword ptr %[sunB];"
+        "fstp dword ptr ds:[eax+0x8];"
+        "add esp, 0x4;"
+        "jmp 0x008016E6;"
+        
+        "Default_1:;"
+        "fld dword ptr ds:[ecx+0x2F4];"
+        "fstp dword ptr ds:[eax];"
+        "fld dword ptr ds:[ecx+0x2F8];"
+        "fstp dword ptr ds:[eax+0x4];"
+        "fld dword ptr ds:[ecx+0x2FC];"
+        "fstp dword ptr ds:[eax+0x8];"
+        "add esp, 0x4;"
+        "jmp 0x008016E6;"
+
+        :
+        : [sunR] "m" (sunR),
+          [sunG] "m" (sunG),
+          [sunB] "m" (sunB)
+        :
+    );
+}
+
+void GetSunPosition()
+{
+    asm(
+        //default
+        "lea eax, ss:[esp+0x2C];" 
+        "push eax;"
+        "mov eax, dword ptr ss:[esp];"
+        
+        "cmp %[sunX], 0x0;"
+        "je Default_2;"
+        
+        // "fld dword ptr %[sunX];"
+        // "fstp dword ptr ds:[eax];"
+        // "fld dword ptr %[sunY];"
+        // "fstp dword ptr ds:[eax+0x4];"
+        // "fld dword ptr %[sunZ];"
+        // "fstp dword ptr ds:[eax+0x8];"
+        // "add esp, 0x4;"
+        // "jmp 0x00801680;"
+        
+        "push eax;"
+        "mov eax, %[sunX];"
+        "mov dword ptr ds:[ecx+0x2DC], eax;"
+        "mov eax, %[sunY];"
+        "mov dword ptr ds:[ecx+0x2E0], eax;"
+        "mov eax, %[sunZ];"
+        "mov dword ptr ds:[ecx+0x2E4], eax;"
+        "pop eax;"
+        
+        "Default_2:;"
+        "fld dword ptr ds:[ecx+0x2DC];"
+        "fstp dword ptr ds:[eax];"
+        "fld dword ptr ds:[ecx+0x2E0];"
+        "fstp dword ptr ds:[eax+0x4];"
+        "fld dword ptr ds:[ecx+0x2E4];"
+        "fstp dword ptr ds:[eax+0x8];"
+        "add esp, 0x4;"
+        "jmp 0x00801680;"
+
+        :
+        : [sunX] "m" (sunX),
+          [sunY] "m" (sunY),
+          [sunZ] "m" (sunZ)
+        :
+    );
+}
+
+
+
 int LuaSetTerrainLightingMultiplier(lua_State *l)
 {
     float mult = luaL_optnumber(l, 1, 0);
@@ -33,3 +128,49 @@ int LuaSetTerrainLightingMultiplier(lua_State *l)
 }
 
 UIRegFunc SetTerrainLightingMultiplierReg{"SetTerrainLightingMultiplier", "SetTerrainLightingMultiplier(mult:float)", LuaSetTerrainLightingMultiplier};
+
+int LuaSetSunColorRGB(lua_State *l)
+{
+    float r = luaL_optnumber(l, 1, 0);
+    float g = luaL_optnumber(l, 2, 0);
+    float b = luaL_optnumber(l, 3, 0);
+    
+    if (r > 255 || g > 255 || b > 255)
+    {
+        sunR = 0;
+        sunG = 0;
+        sunB = 0;
+        return 0;
+    }
+    
+    sunR = r / 100;
+    sunG = g / 100;
+    sunB = b / 100;
+
+    return 0;
+}
+
+UIRegFunc SetSunColorRGBReg{"SetSunColorRGB", "SetSunColorRGB(R:float, G:float, B:float)", LuaSetSunColorRGB};
+
+int LuaSetSunPositionXYZ(lua_State *l)
+{
+    float x = luaL_optnumber(l, 1, 0);
+    float y = luaL_optnumber(l, 2, 0);
+    float z = luaL_optnumber(l, 3, 0);
+    
+    if (x == 0 & y == 0 & z == 0)
+    {
+        sunX = 0;
+        sunY = 0;
+        sunZ = 0;
+        return 0;
+    }
+    
+    sunX = x / 100;
+    sunY = y / 100;
+    sunZ = z / 100;
+
+    return 0;
+}
+
+UIRegFunc SetSunPositionXYZReg{"SetSunPositionXYZ", "SetSunPositionXYZ(X:float, Y:float, Z:float)", LuaSetSunPositionXYZ};


### PR DESCRIPTION
This pr won't be merged in current state. As we discussed in Zulip giving that much control over sun color/position to UI may have some consequences. E.g. too many "fancy" clownlike presets shared via UI mods and then showed on streams, that may scare away new players and also upset mapmakers. So best thing we can do is make 4-5 presets (early morning, noontime, sunset, cloudy weather etc.) hardcoded in engine and then let user to switch between them.

For now all functions are available in UI, so we can find best values for presets which looks ok on common maps (like Setons, Gap etc). Ui functions:
```Python
    SetTerrainLightingMultiplier(float)  #Default value is usually 1.5-1.6
    
    SetSunColorRGB(r, g, b)
    
    SetSunPositionXYZ(x, y, z)         #Description below
```

![изображение](https://github.com/user-attachments/assets/cb9904bc-c348-4ce3-bbf5-93aa47b5e247)


Some examples on seton:
```Python
# Early morning

SetTerrainLightingMultiplier(1.8)
SetSunPositionXYZ(-80, 20, 10)
SetSunColorRGB(255, 255, 128)
```
![123](https://github.com/user-attachments/assets/32dd79a1-161c-46ae-bc77-d878880e3beb)



```Python
# Sunset

SetTerrainLightingMultiplier(1.8)
SetSunPositionXYZ(60, 20, -20)
SetSunColorRGB(212, 64, 38)
```

![изображение](https://github.com/user-attachments/assets/b4ae8b55-4640-43f3-ba3d-8c86a79571f3)


