### PR TITLE
Fix `luaV_settable`

### DIFF
--- a/hooks/luaV_settable.hook
+++ b/hooks/luaV_settable.hook
@@ -1,0 +1,4 @@
+00929450:
+    jmp @luaV_settable_fix
+    nop
+    nop

--- a/include/LuaAPI.h
+++ b/include/LuaAPI.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "global.h"
+#include "lua/lua.h"
 
 #define LUA_IDSIZE 60
 
@@ -49,20 +50,6 @@ typedef struct luaL_reg {
 #define LUA_ERRSYNTAX 3
 #define LUA_ERRMEM 4
 #define LUA_ERRERR 5
-
-#define LUA_TNONE (-1)
-#define LUA_TNIL 0
-#define LUA_TBOOLEAN 1
-#define LUA_TLIGHTUSERDATA 2
-#define LUA_TNUMBER 3
-#define LUA_TSTRING 4
-#define LUA_TTABLE 5
-#define LUA_CFUNCTION 6
-#define LUA_TFUNCTION 7
-#define LUA_TUSERDATA 8
-#define LUA_TTHREAD 9
-#define LUA_TPROTO 10
-#define LUA_TUPVALUE 11
 
 #define LUA_HOOKCALL 0
 #define LUA_HOOKRET 1
@@ -139,41 +126,6 @@ struct TObject {
 };
 
 VALIDATE_SIZE(TObject, 8)
-
-namespace lua
-{
-    struct TObject
-    {
-        int tt;
-        void *value;
-    };
-
-    struct Node
-    {
-        TObject i_key;
-        TObject i_val;
-        Node *next;
-    };
-
-    struct Table
-    {
-        /* lua::GCObject*/ void *next;
-        uint8_t tt;
-        uint8_t marked;
-        uint16_t gap;
-        uint8_t flags;
-        uint8_t lsizenode;
-        // padding byte
-        // padding byte
-        Table *metatable;
-        TObject *array;
-        lua::Node *node;
-        lua::Node *firstfree;
-        /*lua::GCObject*/ void *gclist;
-        int sizearray;
-    };
-
-} // namespace lua
 
 // namespace gpg
 namespace gpg

--- a/include/PatchBase.h
+++ b/include/PatchBase.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#define SHARED extern "C"
+
+#define GPtr(addr, type) \
+  (*(type*)addr)
+
+#define CSTR(name, addr) \
+extern const char name[] asm(#addr);
+
+
+#define GDecl(name, addr, type) \
+  extern type name asm(#addr);
+
+#define WDecl(addr, type) \
+  ((type)*(uintptr_t*)addr)
+
+#define VALIDATE_SIZE(struc, size) \
+  static_assert(sizeof(struc) == size, "Invalid structure size of " #struc);

--- a/include/global.h
+++ b/include/global.h
@@ -2,24 +2,7 @@
 
 #include <cstdint>
 #include "../workflow.cpp"
-
-#define SHARED extern "C"
-
-#define GPtr(addr, type) \
-  (*(type*)addr)
-
-#define CSTR(name, addr) \
-extern const char name[] asm(#addr);
-
-
-#define GDecl(name, addr, type) \
-  extern type name asm(#addr);
-
-#define WDecl(addr, type) \
-  ((type)*(uintptr_t*)addr)
-
-#define VALIDATE_SIZE(struc, size) \
-  static_assert(sizeof(struc) == size, "Invalid structure size of " #struc);
+#include "PatchBase.h"
 
 #define g_CSimDriver			GPtr(0x10C4F50, CSimDriver*)
 #define g_SWldSessionInfo		GPtr(0x10C4F58, SWldSessionInfo*)

--- a/include/lua/lua.h
+++ b/include/lua/lua.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <cstdint>
-
-#define VALIDATE_SIZE(struc, size) \
-    static_assert(sizeof(struc) == size, "Invalid structure size of " #struc);
+#include "PatchBase.h"
 
 #define LUA_TNONE (-1)
 #define LUA_TNIL 0

--- a/include/lua/lua.h
+++ b/include/lua/lua.h
@@ -1,0 +1,158 @@
+#pragma once
+#include <cstdint>
+
+#define VALIDATE_SIZE(struc, size) \
+    static_assert(sizeof(struc) == size, "Invalid structure size of " #struc);
+
+#define LUA_TNONE (-1)
+#define LUA_TNIL 0
+#define LUA_TBOOLEAN 1
+#define LUA_TLIGHTUSERDATA 2
+#define LUA_TNUMBER 3
+#define LUA_TSTRING 4
+#define LUA_TTABLE 5
+#define LUA_CFUNCTION 6
+#define LUA_TFUNCTION 7
+#define LUA_TUSERDATA 8
+#define LUA_TTHREAD 9
+#define LUA_TPROTO 10
+#define LUA_TUPVALUE 11
+
+#define ttype(o) ((o)->tt)
+#define ttisnil(o) (ttype(o) == LUA_TNIL)
+#define ttisnumber(o) (ttype(o) == LUA_TNUMBER)
+#define ttisstring(o) (ttype(o) == LUA_TSTRING)
+#define ttiswstring(o) (ttype(o) == LUA_TWSTRING)
+#define ttistable(o) (ttype(o) == LUA_TTABLE)
+#define ttisfunction(o) (ttype(o) == LUA_TFUNCTION)
+#define ttisboolean(o) (ttype(o) == LUA_TBOOLEAN)
+#define ttisuserdata(o) (ttype(o) == LUA_TUSERDATA)
+#define ttisthread(o) (ttype(o) == LUA_TTHREAD)
+#define ttislightuserdata(o) (ttype(o) == LUA_TLIGHTUSERDATA)
+
+#define CommonHeader \
+    GCObject *next;  \
+    uint8_t tt;      \
+    uint8_t marked
+
+#define MAXTAGLOOP 100
+
+namespace lua
+{
+    typedef struct lua_State lua_State;
+
+    typedef enum
+    {
+        TM_INDEX,
+        TM_NEWINDEX,
+        TM_GC,
+        TM_MODE,
+        TM_EQ, /* last tag method with `fast' access */
+        TM_ADD,
+        TM_SUB,
+        TM_MUL,
+        TM_DIV,
+        TM_POW,
+        TM_UNM,
+        TM_LT,
+        TM_LE,
+        TM_CONCAT,
+        TM_CALL,
+        TM_N /* number of elements in the enum */
+    } TMS;
+
+    struct TObject
+    {
+        int tt;
+        void *value;
+    };
+
+    struct Node
+    {
+        TObject i_key;
+        TObject i_val;
+        Node *next;
+    };
+
+    typedef struct GCObject GCObject;
+
+    struct Table
+    {
+        CommonHeader;
+        uint16_t gap;
+        uint8_t flags;
+        uint8_t lsizenode;
+        // padding byte
+        // padding byte
+        Table *metatable;
+        TObject *array;
+        lua::Node *node;
+        lua::Node *firstfree;
+        /*lua::GCObject*/ void *gclist;
+        int sizearray;
+    };
+
+    typedef TObject *StkId;
+
+    typedef struct global_State
+    {
+        char strt[0xC];
+        lua::GCObject *rootgc;
+        lua::GCObject *rootgc1;
+        lua::GCObject *rootudata;
+        lua::GCObject *tmudata;
+        char buff[8];
+        int GCthreshold;
+        void *panic;
+        int nblocks;
+        lua::TObject _registry;
+        lua::TObject _defaultmeta;
+        lua::lua_State *mainthread;
+        lua::lua_State *lstate;
+        lua::Node dummynode[1];
+        void *tmname[15];
+        char pad[288];
+    } global_State;
+
+    typedef struct lua_State
+    {
+        CommonHeader;
+        lua::TObject *top;
+        lua::StkId base;
+        global_State *l_G;
+        void *ci;
+        lua::StkId stack_last;
+        char pad[0x40 + 20];
+    } lua_State;
+
+} // namespace lua
+// const int a = sizeof(lua::global_State);
+VALIDATE_SIZE(lua::lua_State, 0x70);
+VALIDATE_SIZE(lua::global_State, 0x1B8);
+static_assert(offsetof(lua::global_State, tmname) == 0x5c, "Invalid tmname offset");
+
+#define setobj(obj1, obj2)               \
+    {                                    \
+        const lua::TObject *o2 = (obj2); \
+        lua::TObject *o1 = (obj1);       \
+        o1->tt = o2->tt;                 \
+        o1->value = o2->value;           \
+    }
+
+#define luaD_checkstack(L, n)                                                      \
+    if ((char *)L->stack_last - (char *)L->top <= (n) * (int)sizeof(lua::TObject)) \
+        luaD_growstack(L, n);
+
+#define G(L) (L->l_G)
+#define gfasttm(g, et, e) \
+    (((et)->flags & (1u << (e))) ? NULL : luaT_gettm(et, e, (g)->tmname[e]))
+
+#define fasttm(l, et, e) gfasttm(G(l), et, e)
+
+const lua::TObject *__cdecl luaT_gettm(lua::Table *events, char event, void *ename) asm("0x00928420");
+lua::lua_State *__cdecl luaD_growstack(lua::lua_State *L, int n) asm("0x00913990");
+void __cdecl luaD_call(lua::lua_State *L, lua::StkId func, int nResults) asm("0x00914430");
+lua::TObject *__cdecl luaH_set(lua::lua_State *L, lua::Table *t, const lua::TObject *key) asm("0x00927560");
+const lua::TObject *__cdecl luaT_gettmbyobj(lua::lua_State *L, const lua::TObject *o, lua::TMS event) asm("0x00928450");
+void luaG_runerror(lua::lua_State *L, const char *msg, ...) asm("0x00913270");
+void __cdecl luaG_typeerror(lua::lua_State *L, const lua::TObject *obj, const char *oper) asm("0x009133A0");

--- a/section/Lua/Patches/luaV_settable.cxx
+++ b/section/Lua/Patches/luaV_settable.cxx
@@ -1,0 +1,51 @@
+
+#include "luaV_settable.h"
+
+static void callTM(
+    lua::lua_State *L,
+    const lua::TObject *f,
+    const lua::TObject *p1,
+    const lua::TObject *p2,
+    const lua::TObject *p3)
+{
+    setobj(L->top, f);      /* push function */
+    setobj(L->top + 1, p1); /* 1st argument */
+    setobj(L->top + 2, p2); /* 2nd argument */
+    setobj(L->top + 3, p3); /* 3th argument */
+
+    luaD_checkstack(L, 4); /* cannot check before (could invalidate p1...p3) */
+    L->top += 4;
+    luaD_call(L, L->top - 4, 0);
+}
+
+void __cdecl luaV_settable(lua::lua_State *L, const lua::TObject *t, const lua::TObject *key, const lua::TObject *val)
+{
+    lua::TObject temp;
+    for (int loop = 0; loop < MAXTAGLOOP; loop++)
+    {
+        const lua::TObject *tm;
+        if (ttistable(t))
+        { /* `t' is a table? */
+            lua::Table *h = (lua::Table *)t->value;
+            lua::TObject *oldval = luaH_set(L, h, key); /* do a primitive set */
+            if (!ttisnil(oldval) ||                     /* result is no nil? */
+                (tm = fasttm(L, h->metatable, lua::TM_NEWINDEX)) == NULL)
+            { /* or no TM? */
+                setobj(oldval, val);
+                return;
+            }
+            /* else will try the tag method */
+        }
+        else if (ttisnil(tm = luaT_gettmbyobj(L, t, lua::TM_NEWINDEX)))
+            luaG_typeerror(L, t, "index");
+        if (ttisfunction(tm))
+        {
+            callTM(L, tm, t, key, val);
+            return;
+        }
+        /* else repeat with `tm' */
+        setobj(&temp, tm); /* avoid pointing inside table (may rehash) */
+        t = &temp;
+    }
+    luaG_runerror(L, "loop in settable");
+}

--- a/section/Lua/Patches/luaV_settable.cxx
+++ b/section/Lua/Patches/luaV_settable.cxx
@@ -18,7 +18,7 @@ static void callTM(
     luaD_call(L, L->top - 4, 0);
 }
 
-void __cdecl luaV_settable(lua::lua_State *L, const lua::TObject *t, const lua::TObject *key, const lua::TObject *val)
+SHARED void __cdecl luaV_settable_fix(lua::lua_State *L, const lua::TObject *t, const lua::TObject *key, const lua::TObject *val)
 {
     lua::TObject temp;
     for (int loop = 0; loop < MAXTAGLOOP; loop++)

--- a/section/Lua/Patches/luaV_settable.h
+++ b/section/Lua/Patches/luaV_settable.h
@@ -1,0 +1,2 @@
+#include "lua/lua.h"
+


### PR DESCRIPTION
## The memo
There were multiple reports of CTD with this error:
```
EXCEPTION_ACCESS_VIOLATION (0xc0000005) at address 0x009279a6
    attempted to read memory at 0x00000010
```
When analyzing stacktrace `0x009279A6 0x009275F9 0x00929475 0x0092A1D9 0x009144B0 0x00929C47 0x00929425`
It seems like error belongs to `luaV_settable` which according to [Lua bugs page had this problem](https://www.lua.org/bugs.html#5.1-6:~:text=luaV_settable%20may%20invalidate%20a%20reference%20to%20a%20table%20and%20try%20to%20reuse%20it.).
 And upon investingating code I compared Lua 5.0.3 and 5.1.5 and our decompiled version:
 5.1.5
```C
void luaV_settable (lua_State *L, const TValue *t, TValue *key, StkId val) {
  int loop;
  TValue temp;
  for (loop = 0; loop < MAXTAGLOOP; loop++) {
    const TValue *tm;
    if (ttistable(t)) {  /* `t' is a table? */
      Table *h = hvalue(t);
      TValue *oldval = luaH_set(L, h, key); /* do a primitive set */
      if (!ttisnil(oldval) ||  /* result is no nil? */
          (tm = fasttm(L, h->metatable, TM_NEWINDEX)) == NULL) { /* or no TM? */
        setobj2t(L, oldval, val);
        h->flags = 0;
        luaC_barriert(L, h, val);
        return;
      }
      /* else will try the tag method */
    }
    else if (ttisnil(tm = luaT_gettmbyobj(L, t, TM_NEWINDEX)))
      luaG_typeerror(L, t, "index");
    if (ttisfunction(tm)) {
      callTM(L, tm, t, key, val);
      return;
    }
    /* else repeat with `tm' */
    setobj(L, &temp, tm);  /* avoid pointing inside table (may rehash) */
    t = &temp;
  }
  luaG_runerror(L, "loop in settable");
}
```

5.0.3
```C
void luaV_settable (lua_State *L, const TObject *t, TObject *key, StkId val) {
  const TObject *tm;
  int loop = 0;
  do {
    if (ttistable(t)) {  /* `t' is a table? */
      Table *h = hvalue(t);
      TObject *oldval = luaH_set(L, h, key); /* do a primitive set */
      if (!ttisnil(oldval) ||  /* result is no nil? */
          (tm = fasttm(L, h->metatable, TM_NEWINDEX)) == NULL) { /* or no TM? */
        setobj2t(oldval, val);  /* write barrier */
        return;
      }
      /* else will try the tag method */
    }
    else if (ttisnil(tm = luaT_gettmbyobj(L, t, TM_NEWINDEX)))
      luaG_typeerror(L, t, "index");
    if (ttisfunction(tm)) {
      callTM(L, tm, t, key, val);
      return;
    }
    t = tm;  /* else repeat with `tm' */ 
  } while (++loop <= MAXTAGLOOP);
  luaG_runerror(L, "loop in settable");
}
```
<img width="701" height="589" alt="image" src="https://github.com/user-attachments/assets/a6860f46-b483-4f61-b4ea-ce1c9bd775de" />

I applied the line that fixes this issue. However I couldn't come up with Lua script that could consistently crash to compare my solution with current game's implementation.

Credits to @Hdt80bro for  decompiled parts and @lL1l1 for reports.

## Checklist
- [ ] Read all guides
- [ ] Clear naming of variables and structs
- [ ] Add new data into moho.h/global.h/Info.txt
- [ ] Add description of changes to [README.md](/README.md)
- [ ] Add test hints/instructions
