### PR TITLE
sim Unit:ForceReclaim(bool)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -363,5 +363,11 @@ These new features have been added in a backwards compatible manner
   - section/SimArmyCreate.cpp
 
 - Add `Unit:ForceAltFootPrint` that forces game to use AltFootprint for the unit (applied to Salem in particular)
+  - hooks/MohoEntityVariableData.hook
   - hooks/EntityGetFootprint.cpp
   - section/EntityGetFootprint.cpp
+  
+- Add `Unit:ForceReclaim(bool)` When 'true' engineer will continue reclaiming even if both (mass and energy) storages are full
+  - hooks/MohoEntityVariableData.hook
+  - hooks/UnitForceReclaim.hook
+  - section/UnitForceReclaim.cpp

--- a/hooks/EntityGetFootprint.hook
+++ b/hooks/EntityGetFootprint.hook
@@ -1,8 +1,3 @@
-//Moho::SSTIEntityVariableData::SSTIEntityVariableData
-0x00558823:
-    mov dword ptr [eax+0x0A4], ecx // 0x0A5 bool forceAltFootprint
-
-
 //  Moho::Entity::GetFootprint
 0x006788A5:
     jmp @asm__GetFootprint

--- a/hooks/MohoEntityVariableData.hook
+++ b/hooks/MohoEntityVariableData.hook
@@ -1,0 +1,5 @@
+//Moho::SSTIEntityVariableData::SSTIEntityVariableData
+0x00558823:
+    mov dword ptr [eax+0x0A4], ecx // 0x0A5 bool forceAltFootprint
+                                   // 0x0A6 bool isForceReclaim
+                                   // 0x0A7 bool empty

--- a/hooks/UnitForceReclaim.hook
+++ b/hooks/UnitForceReclaim.hook
@@ -1,0 +1,4 @@
+0x0061BC07:
+    jmp @asm__IsForceReclaim
+    nop
+    nop

--- a/section/UnitForceReclaim.cpp
+++ b/section/UnitForceReclaim.cpp
@@ -1,0 +1,46 @@
+#include "CObject.h"
+#include "magic_classes.h"
+#include "moho.h"
+
+
+void asm__IsForceReclaim()
+{
+	asm(
+        "mov eax, dword ptr ds:[ebp+0x1C];" // entity
+        "mov al, byte ptr ss:[eax+0x126];"  // entity->isForceReclaim
+        
+        "test al, al;"
+        "jz Exit;"
+        
+        "mov byte ptr ss:[esp+0x13], 0x0;" // energyStorageIsFull = false
+        "mov byte ptr ss:[esp+0x12], 0x0;" // massStorageIsFull   = false
+        
+        "Exit:;"
+        "lea edx, ss:[esp+0x94];" //default code
+        "jmp 0x0061BC0E;"
+	);
+}
+
+
+int ForceReclaim(lua_State *L)
+{
+    if (lua_gettop(L) != 2)
+        L->LuaState->Error(s_ExpectedButGot, __FUNCTION__, 2, lua_gettop(L));
+    auto res = GetCScriptObject<Unit>(L, 1);
+    if (res.IsFail())
+        L->LuaState->Error("%s", res.reason);
+
+    void *unit = res.object;
+    bool flag = lua_toboolean(L, 2);
+
+    GetField<bool>(unit, 8+0x11E) = flag; // bool isForceReclaim
+
+    return 0;
+}
+using UnitMethodReg = SimRegFuncT<0x00E2D550, 0x00F8D704>;
+
+UnitMethodReg ForceReclaimReg{
+    "ForceReclaim",
+    "",
+    ForceReclaim,
+    "Unit"};


### PR DESCRIPTION
Added Unit:ForceReclaim(bool)

When enabled engineer will continue reclaiming even if storage is full.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Lua-accessible Force Reclaim action for units.
  * Improved unit construction initialization to propagate new unit flags.

* **Behaviour Changes**
  * Entity footprint handling now bypasses the previous alternate-footprint path.

* **Chores**
  * Added underlying entity variable support to store new unit flags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->