### PR TITLE
Pathfinding improvements

### DIFF
--- a/hooks/PathfindingTweaks.hook
+++ b/hooks/PathfindingTweaks.hook
@@ -1,0 +1,3 @@
+0x005AF8D5:
+    jmp @asm__PersonalPositioningDistanceCheck
+    nop

--- a/hooks/PathfindingTweaks.hook
+++ b/hooks/PathfindingTweaks.hook
@@ -1,3 +1,2 @@
 0x005AF8D5:
-    jmp @asm__PersonalPositioningDistanceCheck
-    nop
+    fld dword ptr [@navPersonalPosMaxDistance]

--- a/section/PathfindingTweaks.cpp
+++ b/section/PathfindingTweaks.cpp
@@ -6,17 +6,6 @@
 
 float navPersonalPosMaxDistance = 50.0;
 
-volatile void asm__PersonalPositioningDistanceCheck()
-{
-    asm(
-        "fld %[navPersonalPosMaxDistance];"
-        "jmp 0x005AF8DB;"
-        
-        :
-        : NON_GENERAL_REG(navPersonalPosMaxDistance)
-        : 
-    );
-}
 
 int SetNavIndividualPosMaxDistance(lua_State *L) {
     navPersonalPosMaxDistance = luaL_optnumber(L, 1, 50.0);

--- a/section/PathfindingTweaks.cpp
+++ b/section/PathfindingTweaks.cpp
@@ -1,0 +1,26 @@
+#include "CObject.h"
+#include "magic_classes.h"
+#include "moho.h"
+#include "global.h"
+#define NON_GENERAL_REG(var_) [var_] "g"(var_)
+
+float navPersonalPosMaxDistance = 50.0;
+
+volatile void asm__PersonalPositioningDistanceCheck()
+{
+    asm(
+        "fld %[navPersonalPosMaxDistance];"
+        "jmp 0x005AF8DB;"
+        
+        :
+        : NON_GENERAL_REG(navPersonalPosMaxDistance)
+        : 
+    );
+}
+
+int SetNavIndividualPosMaxDistance(lua_State *L) {
+    navPersonalPosMaxDistance = luaL_optnumber(L, 1, 50.0);
+
+    return 0;
+}
+SimRegFunc SetNavDistanceReg{"SetNavigatorPersonalPosMaxDistance", "", SetNavIndividualPosMaxDistance};


### PR DESCRIPTION
Added sim function: **SetNavigatorPersonalPosMaxDistance(float)**  Default value is 50.

useful console commands for testing:
dbg navwaypoints
dbg navpath
dbg navsteering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tunable navigation distance setting for pathfinding and personal positioning.
  * Exposed a runtime-adjustable interface so scripts can change the navigator personal-position max distance.
  * Applied a lightweight runtime patch so the new setting is used by the pathfinding logic without other behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->