### PR TITLE
Let `GetTextureDimensions` accept second argument

### DIFF
--- a/hooks/GetTextureDimensions.hook
+++ b/hooks/GetTextureDimensions.hook
@@ -1,4 +1,4 @@
 
 # cfunc_GetTextureDimensions+0x39
 0x00780B29:
-    cmp     eax, 3 # from 2 args
+    cmp     eax, 3 # from only accepting 1 arg to 2 (it's used in a less-than operation)

--- a/hooks/GetTextureDimensions.hook
+++ b/hooks/GetTextureDimensions.hook
@@ -1,0 +1,4 @@
+
+# cfunc_GetTextureDimensions+0x39
+0x00780B29:
+    cmp     eax, 3 # from 2 args


### PR DESCRIPTION
`GetTextureDimensions` documents an optional second argument called `border` that adds the number to both dimensions all around. This is supremely unhelpful, but it's low-hanging fruit. 

Addresses #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal texture dimension handling to support additional parameters, improving system flexibility for texture processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->