### PR TITLE
Enable `dbg_Emitter`

### DIFF
--- a/hooks/EnableConsoleCommands.cpp
+++ b/hooks/EnableConsoleCommands.cpp
@@ -6,7 +6,7 @@ asm(R"(
 	# just barely doesn't fit, slide up one into the empty description and update pointer
 	.section h2; .set h2,0xF59C88; .word 0xE23900 - 1
 	.section h3; .set h3,0xE23900 - 1; .string "dbg_EfxBeams"
-	#.section h4; .set h4,0xE23EC4; .string "dbg_Emitter" # actually unused by the engine
+	.section h4; .set h4,0xE23EC4; .string "dbg_Emitter"
 	.section h5; .set h5,0xE26858; .string "dbg_Trail"
 	.section h6; .set h6,0xE2698C; .string "dbg_CollisionBeam"
 	.section h7; .set h7,0xE294E8; .string "dbg_Projectile"


### PR DESCRIPTION
It appears this console command isn't useless after all. It has a use at `0x0065DCA8`.