### PR TITLE
Alternative fix for units aiming 1 tick ahead

### DIFF
--- a/hooks/WeaponAimFix.hook
+++ b/hooks/WeaponAimFix.hook
@@ -1,0 +1,2 @@
+0x00631A72:
+    jmp @asm__fixWeaponAim

--- a/hooks/WeaponAimFix.hook
+++ b/hooks/WeaponAimFix.hook
@@ -1,2 +1,2 @@
-0x00631A72:
+0x00631A0A:
     jmp @asm__fixWeaponAim

--- a/section/WeaponAimFix.cpp
+++ b/section/WeaponAimFix.cpp
@@ -1,0 +1,45 @@
+// Nomander's comment from Github explaining what are we doing here:
+//
+// "After .text:00631A6D the aim manipulator aiming calculation adds the target's velocity to the target point. 
+// The remainder of the calculations is correctly calculating ballistics, but this specific part needs to check if 
+// the target's position was already updated since it's part of the entity task tick stage, which can be done by 
+// comparing the current tick of the sim and the last update tick of the entity."
+
+void asm__fixWeaponAim()
+{
+    asm(
+                                               // default
+        "movss xmm0, dword ptr ds:[eax+0x4];"  // targetPos.x
+        "movss xmm1, dword ptr ss:[eax];"      // targetPos.z 
+        "movss xmm2, dword ptr ss:[eax+0x8];"  // targetPos.y 
+        
+        "mov eax, dword ptr ds:[esi+0x4];"     // CAiTarget->entity
+        "test eax, eax;"
+        
+        "je EXIT;"                             // no targetEnity when groundfiring
+        
+        "push ebx;"
+        "cmp dword ptr ds:[esi+0x10], 0xF;"    // 0xF = auto fire, no attack order.
+                                               // the route to entity->lastUpdateTick is different
+        "je noAttackOrder;"                    // when there is an attack order
+        
+        "mov eax, dword ptr ds:[eax+0x5C];"
+        "sub eax, 0x5C;"
+        
+        "noAttackOrder:;"
+        "mov ebx, dword ptr ds:[eax+0x144];"
+        "mov ebx, dword ptr ds:[ebx+0x900];"   // sim->currentTick
+        "cmp ebx, dword ptr ds:[eax+0x170];"   // entity->lastUpdateTick
+        "pop ebx;"
+        
+        "je EXIT;"                             // entityLastUpdateTick == currentSimTick means the target's pos is up-to-date
+                                               // so no need to add target's velocity
+        
+        "addss xmm0, dword ptr ss:[esp+0x3C];" // targetVel.x
+        "addss xmm1, dword ptr ss:[esp+0x38];" // targetVel.z
+        "addss xmm2, dword ptr ss:[esp+0x40];" // targetVel.y
+        
+        "EXIT:;"
+        "jmp 0x00631A92;"
+    );
+}

--- a/section/WeaponAimFix.cpp
+++ b/section/WeaponAimFix.cpp
@@ -1,45 +1,23 @@
-// Nomander's comment from Github explaining what are we doing here:
-//
-// "After .text:00631A6D the aim manipulator aiming calculation adds the target's velocity to the target point. 
-// The remainder of the calculations is correctly calculating ballistics, but this specific part needs to check if 
-// the target's position was already updated since it's part of the entity task tick stage, which can be done by 
-// comparing the current tick of the sim and the last update tick of the entity."
-
+// Fixes aim manipulators aiming 1 tick ahead of entities that have already updated their position.
 void asm__fixWeaponAim()
 {
+    // inputs:
+    // eax = WeakObject<Entity> *p_EntityWeakObj (Entity + 0x4 *)
+    // esp+0x44 = Vector3f vec3f
     asm(
-                                               // default
-        "movss xmm0, dword ptr ds:[eax+0x4];"  // targetPos.x
-        "movss xmm1, dword ptr ss:[eax];"      // targetPos.z 
-        "movss xmm2, dword ptr ss:[eax+0x8];"  // targetPos.y 
-        
-        "mov eax, dword ptr ds:[esi+0x4];"     // CAiTarget->entity
-        "test eax, eax;"
-        
-        "je EXIT;"                             // no targetEnity when groundfiring
-        
-        "push ebx;"
-        "cmp dword ptr ds:[esi+0x10], 0xF;"    // 0xF = auto fire, no attack order.
-                                               // the route to entity->lastUpdateTick is different
-        "je noAttackOrder;"                    // when there is an attack order
-        
-        "mov eax, dword ptr ds:[eax+0x5C];"
-        "sub eax, 0x5C;"
-        
-        "noAttackOrder:;"
-        "mov ebx, dword ptr ds:[eax+0x144];"
-        "mov ebx, dword ptr ds:[ebx+0x900];"   // sim->currentTick
-        "cmp ebx, dword ptr ds:[eax+0x170];"   // entity->lastUpdateTick
-        "pop ebx;"
-        
-        "je EXIT;"                             // entityLastUpdateTick == currentSimTick means the target's pos is up-to-date
-                                               // so no need to add target's velocity
-        
-        "addss xmm0, dword ptr ss:[esp+0x3C];" // targetVel.x
-        "addss xmm1, dword ptr ss:[esp+0x38];" // targetVel.z
-        "addss xmm2, dword ptr ss:[esp+0x40];" // targetVel.y
-        
-        "EXIT:;"
-        "jmp 0x00631A92;"
+        "lea ecx, ds:[eax-4];"      // ecx = p_EntityWeakObj->GetObject();
+        "mov eax, ds:[ecx+0x148];"  // eax = Entity.sim;
+        "mov eax, ds:[eax+0x900];"  // eax = Sim.cur_tick;
+        "mov edx, ds:[ecx+0x174];"  // edx = Entity.lastUpdateTick;
+        "cmp eax, edx;"             // if cur_tick == lastUpdateTick
+        "je 0x00631A2F;"            // then output 0-vector and end
+        "mov eax, ds:[ecx];"        // eax = Entity.__vftable;
+        "mov eax, ds:[eax+0x3C];"   // eax = Entity_vtbl.GetVelocity;
+        "lea edx, ds:[esp+0x44];"   // edx = &vec3f
+        "push edx;"                 // ^0.4 = &vec3f
+        "call eax;"                 // eax = GetVelocity(Entity@<ecx>, Vector3f *@<^0.4>)
+        "jmp 0x00631A45;"           // end
     );
+    // outputs:
+    // eax = Vector3f *targetVelocityToAdd
 }


### PR DESCRIPTION
Fixes #122. Currently it's still a little broken because an ML spawned after a mantis shoots behind the mantis and misses for some reason. The laser does hit though.

Also I guess I need to learn C++ and get all the offsets into structs/classes then rewrite the patch.

To test: spawn an monkeylord, then a mantis, then an monkeylord. Have the mantis run perpendicular to the ML. Both ML should be able to hit the mantis with projectiles and lasers, both when on an attack order and when not.
```
   CreateUnitAtMouse('url0402', 1,   24.00,    7.00, -0.00000)
   CreateUnitAtMouse('url0107', 0,   -1.00,  -11.00, -0.00000)
   CreateUnitAtMouse('url0402', 1,  -23.00,    4.00, -0.00000)
```

## Checklist
- [ ] Read all guides
- [ ] Clear naming of variables and structs
- [ ] Add new data into moho.h/global.h/Info.txt
- [ ] Add description of changes to [README.md](/README.md)
- [x] Add test hints/instructions
