### PR TITLE
Add Sim Lua checksum

### DIFF
--- a/hooks/LuaSimCheckSum.hook
+++ b/hooks/LuaSimCheckSum.hook
@@ -1,0 +1,2 @@
+0x004CEE33:
+    call @lua_dochecksum

--- a/include/global.h
+++ b/include/global.h
@@ -149,13 +149,13 @@ struct Result {
   inline bool IsFail() { return reason != nullptr; }
 };
 
-template <typename T>
+template <typename T=void*>
 T Offset(void *ptr, size_t offset)
 {
     return (T)(((char *)ptr) + offset);
 }
 
-template <typename T>
+template <typename T=void*>
 T &GetField(void *ptr, size_t offset)
 {
     return *Offset<T *>(ptr, offset);

--- a/section/LuaSimCheckSum/LuaSimCheckSum.cxx
+++ b/section/LuaSimCheckSum/LuaSimCheckSum.cxx
@@ -1,0 +1,24 @@
+#include "LuaSimCheckSum.h"
+
+int Md5_Writer(lua_State *L, const void *p, size_t sz, void *ud)
+{
+    gpg__MD5Context__Update(ud, p, sz);
+    return 0;
+}
+
+SHARED void __cdecl lua_dochecksum(lua_State *L, int, int)
+{
+    void *sim = lua_getglobaluserdata(L);
+    if (sim == nullptr)
+    {
+        lua_call(L, 0, 0);
+        return;
+    }
+    void *md5 = Offset(sim, 0x50);
+    lua_dump(L, Md5_Writer, md5);
+    // string s;
+    // gpg__MD5Digest__ToString(md5, &s);
+    // LogF("Checksum: %s", s.data());
+    lua_call(L, 0, 0);
+    return;
+}

--- a/section/LuaSimCheckSum/LuaSimCheckSum.h
+++ b/section/LuaSimCheckSum/LuaSimCheckSum.h
@@ -1,0 +1,10 @@
+#include "global.h"
+#include "LuaAPI.h"
+
+typedef int (*lua_Chunkwriter)(lua_State *L, const void *p,
+                               size_t sz, void *ud);
+
+int __cdecl lua_pcallF(lua_State *L, int nargs, int nResults) asm("0x0090D430");
+int __cdecl lua_dump(lua_State *L, lua_Chunkwriter writer, void *ud) asm("0x0090D610");
+string *__thiscall gpg__MD5Digest__ToString(void *_this, string *result) asm("0x008E5910");
+void __thiscall gpg__MD5Context__Update(/* gpg::MD5Context */ void *_this, const void *block, size_t size) asm("0x008E5870");


### PR DESCRIPTION
Include loaded lua files into sim checksum. It uses lua's bytecode for checksum via `lua_dump` function.