### PR TITLE
Fix weapons aim one tick ahead (C++)

### DIFF
--- a/hooks/Aim.hook
+++ b/hooks/Aim.hook
@@ -2,6 +2,7 @@ target_velocity = 0x38
 shooter_pos = 0x64
 aim_pos = 0x20
 dist = 0x1C
+# cai_target = esi
 0x00631A72:
     mov ecx, esi
     push eax                              # target_pos

--- a/hooks/Aim.hook
+++ b/hooks/Aim.hook
@@ -1,0 +1,17 @@
+target_velocity = 0x38
+shooter_pos = 0x64
+aim_pos = 0x20
+dist = 0x1C
+0x00631A72:
+    mov ecx, esi
+    push eax                              # target_pos
+    lea eax, [esp + 4 + target_velocity]
+    push eax
+    lea eax, [esp + 8 + shooter_pos]
+    push eax
+    lea eax, [esp + 12 + aim_pos]
+    push eax
+    call @AimAddVelocity
+    sub esp, 4                            # dead
+    fst dword ptr [esp + dist]
+    jmp 0x00631AD9

--- a/hooks/Aim.hook
+++ b/hooks/Aim.hook
@@ -16,3 +16,6 @@ dist = 0x1C
     sub esp, 4                            # dead
     fst dword ptr [esp + dist]
     jmp 0x00631AD9
+    nop
+    nop
+    nop

--- a/include/Maths.h
+++ b/include/Maths.h
@@ -1,0 +1,95 @@
+#pragma once
+#include <cmath>
+
+class Vector3f
+{
+public:
+	float x, y, z;
+
+	Vector3f() : x(0.0f), y(0.0f), z(0.0f) {}
+	Vector3f(float x_, float y_, float z_) : x(x_), y(y_), z(z_) {}
+
+	Vector3f(const Vector3f &other) : x(other.x), y(other.y), z(other.z) {}
+
+	Vector3f &operator=(const Vector3f &other)
+	{
+		if (this != &other)
+		{
+			x = other.x;
+			y = other.y;
+			z = other.z;
+		}
+		return *this;
+	}
+
+	Vector3f operator+(const Vector3f &other) const
+	{
+		return Vector3f(x + other.x, y + other.y, z + other.z);
+	}
+
+	Vector3f operator-(const Vector3f &other) const
+	{
+		return Vector3f(x - other.x, y - other.y, z - other.z);
+	}
+
+	Vector3f operator*(float scalar) const
+	{
+		return Vector3f(x * scalar, y * scalar, z * scalar);
+	}
+
+	friend Vector3f operator*(float scalar, const Vector3f &vec)
+	{
+		return vec * scalar;
+	}
+
+	float dot(const Vector3f &other) const
+	{
+		return x * other.x + y * other.y + z * other.z;
+	}
+
+	Vector3f cross(const Vector3f &other) const
+	{
+		return Vector3f(
+			y * other.z - z * other.y,
+			z * other.x - x * other.z,
+			x * other.y - y * other.x);
+	}
+
+	float length() const
+	{
+		return sqrtf(x * x + y * y + z * z);
+	}
+
+	Vector3f normalized() const
+	{
+		float len = length();
+		if (len > 0)
+			return {x / len, y / len, z / len};
+
+		return *this;
+	}
+
+	Vector3f &operator+=(const Vector3f &other)
+	{
+		x += other.x;
+		y += other.y;
+		z += other.z;
+		return *this;
+	}
+
+	Vector3f &operator-=(const Vector3f &other)
+	{
+		x -= other.x;
+		y -= other.y;
+		z -= other.z;
+		return *this;
+	}
+
+	Vector3f &operator*=(float scalar)
+	{
+		x *= scalar;
+		y *= scalar;
+		z *= scalar;
+		return *this;
+	}
+};

--- a/include/global.h
+++ b/include/global.h
@@ -149,13 +149,13 @@ struct Result {
   inline bool IsFail() { return reason != nullptr; }
 };
 
-template <typename T>
+template <typename T=void*>
 T Offset(void *ptr, size_t offset)
 {
     return (T)(((char *)ptr) + offset);
 }
 
-template <typename T>
+template <typename T=void*>
 T &GetField(void *ptr, size_t offset)
 {
     return *Offset<T *>(ptr, offset);

--- a/include/moho.h
+++ b/include/moho.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "LuaAPI.h"
+#include "Maths.h"
 
 typedef int BOOL;
 typedef int unk_t;
@@ -111,99 +112,6 @@ typedef int SOCKET;
 struct Vector2f
 { // 0x8 bytes
 	float x, z;
-};
-
-class Vector3f
-{
-public:
-	float x, y, z;
-
-	Vector3f() : x(0.0f), y(0.0f), z(0.0f) {}
-	Vector3f(float x_, float y_, float z_) : x(x_), y(y_), z(z_) {}
-
-	Vector3f(const Vector3f &other) : x(other.x), y(other.y), z(other.z) {}
-
-	Vector3f &operator=(const Vector3f &other)
-	{
-		if (this != &other)
-		{
-			x = other.x;
-			y = other.y;
-			z = other.z;
-		}
-		return *this;
-	}
-
-	Vector3f operator+(const Vector3f &other) const
-	{
-		return Vector3f(x + other.x, y + other.y, z + other.z);
-	}
-
-	Vector3f operator-(const Vector3f &other) const
-	{
-		return Vector3f(x - other.x, y - other.y, z - other.z);
-	}
-
-	Vector3f operator*(float scalar) const
-	{
-		return Vector3f(x * scalar, y * scalar, z * scalar);
-	}
-
-	friend Vector3f operator*(float scalar, const Vector3f &vec)
-	{
-		return vec * scalar;
-	}
-
-	float dot(const Vector3f &other) const
-	{
-		return x * other.x + y * other.y + z * other.z;
-	}
-
-	Vector3f cross(const Vector3f &other) const
-	{
-		return Vector3f(
-			y * other.z - z * other.y,
-			z * other.x - x * other.z,
-			x * other.y - y * other.x);
-	}
-
-	float length() const
-	{
-		return sqrtf(x * x + y * y + z * z);
-	}
-
-	Vector3f normalized() const
-	{
-		float len = length();
-		if (len > 0)
-			return {x / len, y / len, z / len};
-
-		return *this;
-	}
-
-	Vector3f &operator+=(const Vector3f &other)
-	{
-		x += other.x;
-		y += other.y;
-		z += other.z;
-		return *this;
-	}
-
-	Vector3f &operator-=(const Vector3f &other)
-	{
-		x -= other.x;
-		y -= other.y;
-		z -= other.z;
-		return *this;
-	}
-
-	Vector3f &operator*=(float scalar)
-	{
-		x *= scalar;
-		y *= scalar;
-		z *= scalar;
-		return *this;
-	}
 };
 
 struct Vector4f

--- a/section/Aim/Aim.cxx
+++ b/section/Aim/Aim.cxx
@@ -32,7 +32,7 @@ SHARED __thiscall bool CheckNeedAddEntityVelocity(Moho::CAiTarget *cai_target)
     if (blip)
     {
         void *unit_creator_ptr = GetField<void *>(blip, 0x270);
-        if (unit_creator_ptr == nullptr)
+        if (unit_creator_ptr == nullptr || unit_creator_ptr == (void *)4)
             return false;
         void *unit_creator = Offset(unit_creator_ptr, -4);
         entity = Offset(unit_creator, 8);

--- a/section/Aim/Aim.cxx
+++ b/section/Aim/Aim.cxx
@@ -16,7 +16,7 @@ namespace Moho
 }
 
 
-// When targeted manually it uses blip and when not - unit
+// When targeted manually cai_target uses blip and when not - unit's entity
 SHARED __thiscall bool CheckNeedAddEntityVelocity(Moho::CAiTarget *cai_target)
 {
     void *entity = cai_target->entity;

--- a/section/Aim/Aim.cxx
+++ b/section/Aim/Aim.cxx
@@ -1,0 +1,54 @@
+#include "global.h"
+#include "Maths.h"
+
+namespace Moho
+{
+    // requires dtor!!!
+    struct CAiTarget
+    {
+        int targetType;
+        void *entity;
+        void *next_weak_ptr;
+        Vector3f position;
+        int targetPoint;
+        bool targetIsMobile;
+
+        bool HasTargetPoint() const { return targetPoint != -1; }
+    };
+}
+
+SHARED __thiscall bool CheckNeedAddEntityVelocity(Moho::CAiTarget *cai_target)
+{
+    void *entity = cai_target->entity;
+    if (entity == 0 || entity == (void *)4)
+        return false;
+
+    entity = Offset<void *>(entity, -4);
+    int update_tick = GetField<int>(entity, 0x174);
+    void *sim = GetField<void *>(entity, 0x148);
+    int sim_tick = GetField<int>(sim, 0x900);
+    if (sim_tick == update_tick)
+        return false;
+
+    return true;
+}
+
+#include <cmath>
+
+SHARED __thiscall float AimAddVelocity(
+    Moho::CAiTarget *cai_target,
+    Vector3f &aim_pos,
+    const Vector3f &shooter_pos,
+    const Vector3f &target_velocity,
+    const Vector3f &target_pos)
+{
+    if (CheckNeedAddEntityVelocity(cai_target) && cai_target->HasTargetPoint())
+        aim_pos = target_pos + target_velocity;
+    else
+        aim_pos = target_pos;
+
+    return std::sqrt(
+        (aim_pos.x - shooter_pos.x) * (aim_pos.x - shooter_pos.x) +
+        // (aim_pos.y - shooter_pos.y) * (aim_pos.y - shooter_pos.y) +
+        (aim_pos.z - shooter_pos.z) * (aim_pos.z - shooter_pos.z));
+}

--- a/section/Aim/Aim.cxx
+++ b/section/Aim/Aim.cxx
@@ -10,10 +10,8 @@ namespace Moho
         void *entity;
         void *next_weak_ptr;
         Vector3f position;
-        int targetPoint;
+        int targetBoneIdx;
         bool targetIsMobile;
-
-        bool HasTargetPoint() const { return targetPoint != -1; }
     };
 }
 

--- a/section/Aim/Aim.cxx
+++ b/section/Aim/Aim.cxx
@@ -17,13 +17,29 @@ namespace Moho
     };
 }
 
+
+// When targeted manually it uses blip and when not - unit
 SHARED __thiscall bool CheckNeedAddEntityVelocity(Moho::CAiTarget *cai_target)
 {
     void *entity = cai_target->entity;
     if (entity == 0 || entity == (void *)4)
         return false;
 
-    entity = Offset<void *>(entity, -4);
+    entity = Offset(entity, -4);
+
+    void *vtable = GetField(entity, 0x0);
+    void *__thiscall (*IsBlip)(void *) = GetField<void *__thiscall (*)(void *entity)>(vtable, 28);
+    void *blip = IsBlip(entity);
+
+    if (blip)
+    {
+        void *unit_creator_ptr = GetField<void *>(blip, 0x270);
+        if (unit_creator_ptr == nullptr)
+            return false;
+        void *unit_creator = Offset(unit_creator_ptr, -4);
+        entity = Offset(unit_creator, 8);
+    }
+
     int update_tick = GetField<int>(entity, 0x174);
     void *sim = GetField<void *>(entity, 0x148);
     int sim_tick = GetField<int>(sim, 0x900);
@@ -42,11 +58,12 @@ SHARED __thiscall float AimAddVelocity(
     const Vector3f &target_velocity,
     const Vector3f &target_pos)
 {
-    if (CheckNeedAddEntityVelocity(cai_target) && cai_target->HasTargetPoint())
+    if (CheckNeedAddEntityVelocity(cai_target))
         aim_pos = target_pos + target_velocity;
     else
         aim_pos = target_pos;
 
+    // aim_pos = target_pos + target_velocity;
     return std::sqrt(
         (aim_pos.x - shooter_pos.x) * (aim_pos.x - shooter_pos.x) +
         // (aim_pos.y - shooter_pos.y) * (aim_pos.y - shooter_pos.y) +


### PR DESCRIPTION
C++ implementation of https://github.com/FAForever/FA-Binary-Patches/pull/137 and https://github.com/FAForever/FA-Binary-Patches/pull/136 . 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI targeting now accounts for target motion when computing aim points and returns precise 2D distance for targeting.
  * Added a reusable 3D vector type with arithmetic, dot/cross, length, safe normalization, and compound assignments.

* **Refactor**
  * Vector math extracted from the core public header into a dedicated math interface for clearer separation and safer usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->