### PR TITLE
Account for collision offset when picking target point of unit with no target bones

### DIFF
--- a/hooks/CollisionOffsetFix.hook
+++ b/hooks/CollisionOffsetFix.hook
@@ -13,3 +13,4 @@
     pop     ebp                      #
     ret     8                        #
     nop;nop;nop;nop;nop              # 5 nops
+    # There are 200 bytes of dead code. Perhaps we should make a file with such empty blocks to be used for hooking into bigger blocks.

--- a/hooks/CollisionOffsetFix.hook
+++ b/hooks/CollisionOffsetFix.hook
@@ -1,0 +1,14 @@
+
+# Moho::Unit::GetBoneWorldTransform(int)+77
+0x006AA637:
+    mov     ecx, esi                 # esi - Entity
+    push    0xFFFFFFFF               # -1
+    mov     eax, dword ptr [ebp + 8] # result transform
+    push    eax
+    call 0x00679CE0                  # Moho::VTransform * thiscall Moho::Entity::GetBoneWorldTransform(Moho::Entity *this, Moho::VTransform *result, int boneIndex)
+
+    pop     edi                      # function return
+    pop     esi                      #
+    mov     esp, ebp                 #
+    pop     ebp                      #
+    ret     8                        #

--- a/hooks/CollisionOffsetFix.hook
+++ b/hooks/CollisionOffsetFix.hook
@@ -1,6 +1,8 @@
 
 # Moho::Unit::GetBoneWorldTransform(int)+77
 0x006AA637:
+    # Here we are doing call to base class when there is no target bone.
+    # In base class it takes center of collision box and returns it.
     mov     ecx, esi                 # esi - Entity
     push    0xFFFFFFFF               # -1
     mov     eax, dword ptr [ebp + 8] # result transform

--- a/hooks/CollisionOffsetFix.hook
+++ b/hooks/CollisionOffsetFix.hook
@@ -12,3 +12,4 @@
     mov     esp, ebp                 #
     pop     ebp                      #
     ret     8                        #
+    nop;nop;nop;nop;nop              # 5 nops


### PR DESCRIPTION
https://github.com/FAForever/fa/issues/7058 Fix collision offset not being included in calculations for Moho::Unit when there is no target bone.

## Testing

In blueprint for xss0202 set CollisionOffsetY to 3.
Spawn units with command.
```
   CreateUnitAtMouse('xss0202', 0,    0.00,    0.00, -0.00000)
   CreateUnitAtMouse('xes0307', 1,    0.00,    20.00, -0.54245)
```
### Before patch
Neptune will shoot at the model of cruiser, not at the center of its hitbox.
### After patch
Neptune will shoot at the center of cruiser's hitbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collision offset handling during bone world transform retrieval, improving entity interaction and positioning stability. This reduces misplaced or jittery attachments and resolves edge-case collisions that could cause visual or physics glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->