### PR TITLE
Add ui_LifebarOnlyDamaged toggle to hide full-HP lifebars

### DIFF
--- a/Info.txt
+++ b/Info.txt
@@ -265,5 +265,16 @@ const int _Moho_SSTICommandIssueData_Destructor = 0x0057ABB0;
 // MSVCR80.dll
 #define _memmove_s = 0x00A824E7;
 
+// Lifebar render path (LifebarFilter patch)
+// Moho::CWldSession::RenderStrategicIcons: 0x0085B6E0 — strategic icon + lifebar pass
+// sub_85EED0: 0x0085EED0 — lifebar batch enqueue, custom callcnv:
+//   eax = lifebar entry pointer (a 64-byte stack buffer)
+//   ecx = std::vector<...>* (lifebar batch destination)
+// sub_85CD40: 0x0085CD40 — per-entry lifebar drawing function. Reads
+//   v18 = *(float **)eax0 (entry[0] -> unit data ptr)
+//   v18[26] = current HP, v18[27] = max HP
+//   bar fill fraction = v18[26] / v18[27]
+// Patch site: 0x0085C09F — `call sub_85EED0` inside the lifebar block
+
 // New unit categories.
 const char* sCQUEMOV = "CQUEMOV";

--- a/changelog.md
+++ b/changelog.md
@@ -226,6 +226,11 @@ These don't matter except for other assembly patches
 
 These new features have been added in a backwards compatible manner
 
+- Adds `ui_LifebarOnlyDamaged` ConVar — when set to 1, lifebars only appear once a unit takes damage (mirrors Warcraft 3's "Show Lifebars Only When Damaged" toggle). Big FPS gain in dense crowds where most units are undamaged.
+
+  - hooks/LifebarFilter.hook
+  - section/LifebarFilter.cpp
+
 - Enable unused console commands: ren_Steering, dbg_Ballistics, dbg_EfxBeams, dbg_Trail, dbg_CollisionBeam, dbg_Projectile
   - hooks/EnableConsoleCommands.cpp
 - Adds `GetHighlightCommand() - return table of command or nil` to UI (section/GetHighlightCommand.cpp)

--- a/hooks/LifebarFilter.hook
+++ b/hooks/LifebarFilter.hook
@@ -1,0 +1,10 @@
+// Replace the `call sub_85EED0` at the bottom of the lifebar block in
+// Moho::CWldSession::RenderStrategicIcons (0x85C09F, 5 bytes E8 + rel32)
+// with `call LifebarFilter`. Same encoding length, no NOP padding required.
+//
+// LifebarFilter preserves eax/ecx (custom calling convention of sub_85EED0)
+// and either ret's (suppressing the lifebar) or tail-calls sub_85EED0
+// (rendering it).
+
+0x0085C09F:
+    call @LifebarFilter

--- a/section/LifebarFilter.cpp
+++ b/section/LifebarFilter.cpp
@@ -1,0 +1,91 @@
+#include "magic_classes.h"
+
+// Hide lifebars on full-HP units.
+//
+// The lifebar render path in Moho::CWldSession::RenderStrategicIcons
+// enqueues a unit lifebar via sub_85EED0 (0x85EED0) for every visible
+// non-dead unit. With hundreds of undamaged units crowded in one spot the
+// per-frame batching cost dominates the renderer. This patch gates the
+// enqueue on the unit's HP: when `ui_LifebarOnlyDamaged` is set, lifebars
+// only draw for units whose mHealth < mMaxHealth (= took any damage).
+//
+// Default is 0 (vanilla behaviour). Set to 1 to enable the filter.
+//
+// HP/MaxHealth offsets in Moho::UserEntity verified via IDA struct DB:
+//   UserEntity_base.mVarData              @ +0x4C
+//   SSTIEntityVariableData.mHealth        @ +0x18  -> UserEntity +0x64
+//   SSTIEntityVariableData.mMaxHealth     @ +0x1C  -> UserEntity +0x68
+//
+// File-scope C++ globals get the mingw underscore prefix (_g_...) but are
+// NOT C++-mangled, so they can be referenced directly from the asm below.
+
+bool g_LifebarOnlyDamaged = false;
+
+ConDescReg lf_only_damaged_reg{
+    "ui_LifebarOnlyDamaged",
+    "If 1, hide lifebars for units at full HP -- they only appear once a "
+    "unit takes damage. Default 0 (vanilla: always show). Big FPS gain in "
+    "dense crowds where most units are undamaged.",
+    &g_LifebarOnlyDamaged};
+
+// Custom calling convention inherited from sub_85EED0 (callcnv_F3):
+//   eax = lifebar entry pointer (a 64-byte stack buffer prepared by
+//         RenderStrategicIcons; sub_85F140 inside sub_85EED0 memcpy's it
+//         into the batch vector)
+//   ecx = std::vector<...>* (lifebar batch destination)
+//
+// HP/MaxHealth offsets discovered by reading sub_85CD40 (the function
+// that draws each lifebar from the batch vector). It computes the bar
+// fill fraction as:
+//
+//     v18 = *(float **)eax0;            // entry[0] = unit data pointer
+//     v19 = v18[26] / v18[27];          // current / max
+//
+// So the unit's current HP and max HP live at offsets 104 and 108 from
+// the pointer stored at entry[0]. We read the same fields the renderer
+// reads -- whatever struct *entry[0] points to, the renderer treats
+// offsets 104/108 as the HP pair.
+//
+// Inside our filter, after PUSHAD the original eax (the entry pointer)
+// is at [esp+28] (pushad order: edi, esi, ebp, esp, ebx, edx, ecx, eax).
+//
+// On suppress: popad + ret (rewinds the call). On render: popad + jmp
+// to the original sub_85EED0 (tail-call preserves the eax/ecx args).
+asm(R"(
+.section .text,"ax"
+.global LifebarFilter
+LifebarFilter:
+    pushad
+
+    # Filter disabled? -> render normally.
+    mov     dl, ds:_g_LifebarOnlyDamaged
+    test    dl, dl
+    jz      .L_lf_render
+
+    # Recover the entry pointer (saved eax slot in pushad frame).
+    mov     edx, [esp+28]
+    test    edx, edx
+    jz      .L_lf_render
+
+    # entry[0] -> pointer to unit data struct
+    mov     edx, [edx]
+    test    edx, edx
+    jz      .L_lf_render
+
+    # Read the same HP pair sub_85CD40 uses for the bar fill fraction.
+    movss   xmm0, [edx+104]    # current HP   (v18[26])
+    movss   xmm1, [edx+108]    # max HP       (v18[27])
+
+    # Render iff current < max (unit took damage).
+    comiss  xmm1, xmm0
+    ja      .L_lf_render
+
+    # Suppress: restore regs and return without calling sub_85EED0.
+    popad
+    ret
+
+.L_lf_render:
+    # Tail-call the original sub_85EED0 with the original eax/ecx.
+    popad
+    jmp     0x85EED0
+)");


### PR DESCRIPTION
## Summary

- Adds a new ConVar `ui_LifebarOnlyDamaged`. When set to 1, lifebars only appear once a unit takes damage; full-HP units skip the lifebar batch entirely. Default 0 (vanilla behaviour).
- Mirrors Warcraft 3's "Show Lifebars Only When Damaged" option.
- Provides a noticeable FPS gain in dense crowds where most units are undamaged, since the per-frame lifebar batching cost scales with the unit count.

https://discord.com/channels/197033481883222026/1492294267492634674

## Companion PR

The matching settings UI option lives in **FAForever/fa#7085** — adds a HUD toggle that drives this ConVar via `ConExecute`. The two PRs should land together: this binary patch alone makes the ConVar available in the in-game console, the Lua PR alone is a no-op without this patch.

## How it works

Hooks the `call sub_85EED0` at 0x85C09F inside `Moho::CWldSession::RenderStrategicIcons` (the lifebar enqueue inside the per-unit loop). The 5-byte CALL is replaced with `call LifebarFilter` (same encoding length, no padding).

`LifebarFilter` is a small asm filter that:

1. Saves caller state with `pushad`
2. Reads the `ui_LifebarOnlyDamaged` flag — if 0, falls through to the original
3. Reads the same HP fields the actual lifebar drawing function `sub_85CD40` uses for the bar fill fraction:

   ```c
   v18 = *(float **)eax0;        // entry[0] -> unit data ptr
   v19 = v18[26] / v18[27];      // current HP / max HP
   ```

   So we dereference `entry[0]` and read offsets 104 / 108 from the unit data pointer.
4. If `current HP < max HP` → tail-calls `sub_85EED0` (render)
5. If `current HP >= max HP` → returns without enqueueing (suppress)

The custom calling convention of `sub_85EED0` (eax = lifebar entry buffer pointer, ecx = batch vec pointer) is preserved on both paths via `pushad`/`popad`.

## Files

- `hooks/LifebarFilter.hook` — 5-byte CALL replacement at 0x85C09F
- `section/LifebarFilter.cpp` — ConVar registration + asm filter
- `changelog.md` — entry under Additions
- `Info.txt` — documents `sub_85EED0`, `sub_85CD40`, and the entry HP layout

## Test plan

- [ ] Spawn many full-HP units in sandbox, enable `ui_LifebarOnlyDamaged 1` — verify lifebars disappear for all of them
- [ ] Damage a unit — verify its lifebar appears immediately
- [ ] Heal it back to full HP — verify lifebar disappears again
- [ ] Set `ui_LifebarOnlyDamaged 0` — verify all lifebars come back (vanilla behaviour)
- [ ] Verify no crash on unit death / unit creation while filter is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)