### PR TITLE
Fix projectiles falling below zero

### DIFF
--- a/hooks/ProjectileMotionTick.hook
+++ b/hooks/ProjectileMotionTick.hook
@@ -1,0 +1,2 @@
+0x0069BDDA:
+    jmp asm__ProjMotionTick

--- a/section/Fixes/ProjectileMotionTick.cpp
+++ b/section/Fixes/ProjectileMotionTick.cpp
@@ -1,0 +1,17 @@
+void asm__ProjMotionTick()
+{
+    asm(
+    "push    ebp;"
+    "push    esi;"
+    "push    edi;"
+    "mov     ebp, ecx;"
+    "movss   xmm0, dword ptr [ebp+0x78 + 0x24 + 0x10 + 0x4];" // this->sstiData.curTransform.pos.y
+    "comiss  xmm0, ds:0xE4F6E0;" // if y < 0
+    // then
+    "jb  0x0069BDF0;" // on impact
+    // else
+    "jmp 0x0069BDDF;"
+        :
+        :
+        :);
+}


### PR DESCRIPTION
Projectiles that fall below ground (usually during arty wars with arties shooting at the edges of the map) fall indefinitely. it is harmless but confusing since you see yellow dot that doesn't move. It usually happens on maps with no water, but also can occur with water too.
<img width="989" height="754" alt="image" src="https://github.com/user-attachments/assets/c0581e97-a903-4240-95ac-999b3a3a4089" />
<img width="461" height="424" alt="image" src="https://github.com/user-attachments/assets/39a7371c-ce60-4945-bc8d-d94f5acfe9b0" />
After fix projectiles will impact on when they appear below 0.
<img width="689" height="590" alt="image" src="https://github.com/user-attachments/assets/3aba29c9-aa90-4214-8ef3-7eb6c7c9d401" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed projectile motion physics calculations to properly detect and handle ground impact events
  * Improved projectile trajectory handling for more accurate collision detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->