### PR TITLE
Color text in Networkstats menu

### DIFF
--- a/hooks/Networkstats.hook
+++ b/hooks/Networkstats.hook
@@ -1,0 +1,2 @@
+0x0073EFBC:
+    jmp asm__NetworkstatsHook

--- a/section/NetworkStats/Networkstats.cpp
+++ b/section/NetworkStats/Networkstats.cpp
@@ -1,0 +1,26 @@
+#include "Networkstats.h"
+
+void asm__NetworkstatsHook()
+{
+    /*
+        ecx - string
+        esi - column index
+    */
+    asm(
+        "fstp    dword ptr [esp];"
+        "mov     eax, [esp + 0x44 + 4];" // row
+        "pushf;" // store flags since original code makes a cmp before and uses it after
+        "push    ecx;" // preserve these
+        "push    edx;" // preserve these
+        "push    esi;"
+        "push    eax;"
+        "call    %[PickColorForConnections];"
+        "pop     edx;"
+        "pop     ecx;"
+        "popf;"
+        "push    eax;" // color
+        "jmp     0x0073EFC1;"
+        :
+        : [PickColorForConnections] "i"(PickColorForConnections)
+        :);
+}

--- a/section/NetworkStats/Networkstats.cxx
+++ b/section/NetworkStats/Networkstats.cxx
@@ -1,0 +1,47 @@
+#include "Networkstats.h"
+#include <cstdlib>
+#include <array>
+
+const std::array<uint32_t, 21> colors{
+    0xff00FF00, // #00FF00
+    0xff1AFF00, // #1AFF00
+    0xff33FF00, // #33FF00
+    0xff4DFF00, // #4DFF00
+    0xff66FF00, // #66FF00
+    0xff80FF00, // #80FF00
+    0xff99FF00, // #99FF00
+    0xffB3FF00, // #B3FF00
+    0xffCCFF00, // #CCFF00
+    0xffE6FF00, // #E6FF00
+    0xffFFFF00, // #FFFF00
+    0xffFFE600, // #FFE600
+    0xffFFCC00, // #FFCC00
+    0xffFFB300, // #FFB300
+    0xffFF9900, // #FF9900
+    0xffFF8000, // #FF8000
+    0xffFF6600, // #FF6600
+    0xffFF4D00, // #FF4D00
+    0xffFF3300, // #FF3300
+    0xffF00000, // #F00000
+    0xffE00000, // #E00000
+};
+
+int clamp(int value, int min, int max)
+{
+    if (value < min)
+        return min;
+    if (value > max)
+        return max;
+    return value;
+}
+
+SHARED int __thiscall PickColorForConnections(const string *s, int row, int index)
+{
+    if (row > 0 && (index == 4 || index >= 7))
+    {
+        const char *cs = s->data();
+        int v = atoi(cs);
+        return colors[clamp(v, 0, colors.size() - 1)];
+    }
+    return 0xffffffff;
+}

--- a/section/NetworkStats/Networkstats.cxx
+++ b/section/NetworkStats/Networkstats.cxx
@@ -34,13 +34,13 @@ int clamp(int value, int min, int max)
         return max;
     return value;
 }
-
+// Columns  0: army index | 1: nickname | 2: ping | 3: max speed | 4: data | 5: behind | 6: avail | 7-... : data for each player
 SHARED int __thiscall PickColorForConnections(const string *s, int row, int index)
 {
-    if (row > 0 && (index == 4 || index >= 7))
+    if (row > 0 && (index == 4 || index >= 7)) // row 0 is header
     {
         const char *cs = s->data();
-        int v = atoi(cs);
+        int v = __atoi(cs);
         return colors[clamp(v, 0, colors.size() - 1)];
     }
     return 0xffffffff;

--- a/section/NetworkStats/Networkstats.h
+++ b/section/NetworkStats/Networkstats.h
@@ -1,3 +1,5 @@
 #include "global.h"
 
 SHARED int __thiscall PickColorForConnections(const string *s,int row, int index);
+
+int __cdecl __atoi(const char *str) asm("0xA835CE");

--- a/section/NetworkStats/Networkstats.h
+++ b/section/NetworkStats/Networkstats.h
@@ -1,0 +1,3 @@
+#include "global.h"
+
+SHARED int __thiscall PickColorForConnections(const string *s,int row, int index);


### PR DESCRIPTION
Colors data columns in network stats panel for better perception.
<img width="2543" height="1354" alt="image" src="https://github.com/user-attachments/assets/f326f2bc-0cde-455b-9e14-69abae69fb26" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network statistics connections now display color-coded visual indicators reflecting connection quality metrics, utilizing a gradient palette from green to red based on performance data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->