### PR TITLE
Fix elevated Aeon build pools

### DIFF
--- a/hooks/CollisionOffsetFix.hook
+++ b/hooks/CollisionOffsetFix.hook
@@ -1,18 +1,11 @@
 
-# Moho::Unit::GetBoneWorldTransform(int)+77
-0x006AA637:
-    # Here we are doing call to base class when there is no target bone.
-    # In base class it takes center of collision box and returns it.
-    mov     ecx, esi                 # esi - Entity
-    push    0xFFFFFFFF               # -1
-    mov     eax, dword ptr [ebp + 8] # result transform
-    push    eax
-    call 0x00679CE0                  # Moho::VTransform * thiscall Moho::Entity::GetBoneWorldTransform(Moho::Entity *this, Moho::VTransform *result, int boneIndex)
-
-    pop     edi                      # function return
-    pop     esi                      #
-    mov     esp, ebp                 #
-    pop     ebp                      #
-    ret     8                        #
-    nop;nop;nop;nop;nop              # 5 nops
-    # There are 200 bytes of dead code. Perhaps we should make a file with such empty blocks to be used for hooking into bigger blocks.
+# Moho::Unit::GetTargetPoint(int)+0xD
+0x006AB34D:
+    lea     ecx, [edi+8]    # entity
+    push    0xFFFFFFFF      # -1
+    lea     edx, [esp+0x0C] # transform
+    push    edx
+    call    0x00679CE0      # Moho::VTransform *__thiscall Moho::Entity::GetBoneWorldTransform(Moho::Entity *this, Moho::VTransform *a2, int a3)
+    nop
+    nop
+    nop


### PR DESCRIPTION
Turns out [previous patch](https://github.com/FAForever/FA-Binary-Patches/pull/145) for this issue had a side effect that was causing issue like this:
<img width="1529" height="473" alt="image" src="https://github.com/user-attachments/assets/6c39ac67-81cb-412b-a007-82f9af4ec144" />

To mitigate this instead of changing logic of `GetBoneWorldTransform` method of `Unit` class we are changing logic of `GetTargetPoint` the way it uses base class method in case of no target bone provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collision offset handling through targeted binary patch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->