### PR TITLE
Minimap performance improvements

### DIFF
--- a/hooks/Minimap.hook
+++ b/hooks/Minimap.hook
@@ -1,0 +1,11 @@
+# add toggle for rendering range rings in minimap
+0x007D19FF:
+    jmp asm__MinimapRangeRenderHook
+    nop
+    nop
+
+ # disable render of debug info in minimap
+0x007D1BD9:
+    nop;nop;nop;nop
+    nop;nop;nop;nop
+    nop;nop;nop;nop

--- a/section/Minimap/Minimap.cpp
+++ b/section/Minimap/Minimap.cpp
@@ -1,0 +1,12 @@
+void asm__MinimapRangeRenderHook()
+{
+    asm("mov    al, byte ptr _render_minimap_ranges;"
+        "test   al, al;"
+        "jz     0x007D1A3F;"
+        "mov    ecx, [esp+0xAC];"
+        "jmp    0x007D1A06;"
+        :
+        :
+        :
+    );
+}

--- a/section/Minimap/Minimap.cpp
+++ b/section/Minimap/Minimap.cpp
@@ -3,7 +3,7 @@ void asm__MinimapRangeRenderHook()
     asm("mov    al, byte ptr _render_minimap_ranges;"
         "test   al, al;"
         "jz     0x007D1A3F;"
-        "mov    ecx, [esp+0xAC];"
+        "mov    ecx, [esp+0xAC];" // code overwritten by hook
         "jmp    0x007D1A06;"
         :
         :

--- a/section/Minimap/Minimap.cxx
+++ b/section/Minimap/Minimap.cxx
@@ -1,0 +1,4 @@
+#include "magic_classes.h"
+
+SHARED bool render_minimap_ranges = true;
+ConDescReg<bool> ui_RenderMinimapRanges_var("ui_RenderMinimapRanges", "", &render_minimap_ranges);

--- a/section/Minimap/Minimap.cxx
+++ b/section/Minimap/Minimap.cxx
@@ -1,4 +1,4 @@
 #include "magic_classes.h"
 
 SHARED bool render_minimap_ranges = true;
-ConDescReg<bool> ui_RenderMinimapRanges_var("ui_RenderMinimapRanges", "", &render_minimap_ranges);
+ConDescReg<bool> ren_MinimapRanges_var("ren_MinimapRanges", "", &render_minimap_ranges);


### PR DESCRIPTION
* disables render of debug information in minimap
* adds toggle `ren_MinimapRanges` for rendering range rings in minimap (saves up to 50fps when there are lots of units on the map)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggleable setting to control minimap range-rings rendering. Users can now enable or disable the display of range rings on the minimap through configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->