### PR TITLE
Fix track texture scrolling for visible enemy units

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -70,11 +70,11 @@ These don't matter except for other assembly patches
 
 ## Bugs
 
-  * Fix track texture scrolling for visible enemy tracked units.
+- Fix track texture scrolling for visible enemy tracked units.
 
-    * hooks/ReconBlipTrackScrollFix.cpp
-    * section/ReconBlipTrackScrollFix.cpp
-    * 
+  - hooks/ReconBlipTrackScrollFix.cpp
+  - section/ReconBlipTrackScrollFix.cpp
+  - 
 - Remove lingering transport load factor calcuation at aircraft initialization
 
   - hooks/RemoveTransportLoadFactor.cpp

--- a/changelog.md
+++ b/changelog.md
@@ -70,6 +70,11 @@ These don't matter except for other assembly patches
 
 ## Bugs
 
+  * Fix track texture scrolling for visible enemy tracked units.
+
+    * hooks/ReconBlipTrackScrollFix.cpp
+    * section/ReconBlipTrackScrollFix.cpp
+    * 
 - Remove lingering transport load factor calcuation at aircraft initialization
 
   - hooks/RemoveTransportLoadFactor.cpp

--- a/hooks/ReconBlipTrackScrollFix.cpp
+++ b/hooks/ReconBlipTrackScrollFix.cpp
@@ -1,0 +1,9 @@
+#include "../define.h"
+
+// Moho::ReconBlip::BuildSnapshot + 0x1C1
+// Replaces: sub esi, 0xD8
+asm(
+    ".section h0; .set h0,0x005BF171;"
+    "JMP " QU(ReconBlipTrackScrollFix) ";"
+    "NOP;"
+);

--- a/section/ReconBlipTrackScrollFix.cpp
+++ b/section/ReconBlipTrackScrollFix.cpp
@@ -1,0 +1,56 @@
+// Forward the source Unit's four texture-scroll values into the
+// ReconBlip Entity snapshot.
+//
+// Hook context at 0x005BF171:
+//   EDI = ReconBlip
+//   ESI = snapshot builder argument before conversion to Entity snapshot base
+//
+// ReconBlip + 0x270 stores the encoded source Unit reference.
+// A valid reference is converted to the full Unit pointer by subtracting 4.
+//
+// The Unit contains an Entity subobject at +0x08:
+//   Unit + 0x100 = Entity + 0x0F8
+//   Unit + 0x104 = Entity + 0x0FC
+//   Unit + 0x108 = Entity + 0x100
+//   Unit + 0x10C = Entity + 0x104
+//
+// The destination fields are the corresponding scroll values in the
+// Entity snapshot built for the ReconBlip.
+
+void ReconBlipTrackScrollFix()
+{
+    asm(
+        // Replay the six-byte instruction replaced by the hook.
+        "SUB ESI,0xD8;"
+
+        // Preserve the original flags produced by SUB and the registers
+        // used by the bridge.
+        "PUSHFD;"
+        "PUSH EAX;"
+        "PUSH ECX;"
+
+        "MOV EAX,[EDI+0x270];"
+        "TEST EAX,EAX;"
+        "JE ReconBlipTrackScrollFix_Done;"
+        "SUB EAX,4;"
+        "TEST EAX,EAX;"
+        "JE ReconBlipTrackScrollFix_Done;"
+
+        "MOV ECX,[EAX+0x100];"
+        "MOV [ESI+0x88],ECX;"
+        "MOV ECX,[EAX+0x104];"
+        "MOV [ESI+0x8C],ECX;"
+        "MOV ECX,[EAX+0x108];"
+        "MOV [ESI+0x90],ECX;"
+        "MOV ECX,[EAX+0x10C];"
+        "MOV [ESI+0x94],ECX;"
+
+        "ReconBlipTrackScrollFix_Done:;"
+        "POP ECX;"
+        "POP EAX;"
+        "POPFD;"
+
+        // Resume immediately after the replaced instruction.
+        "JMP 0x005BF177;"
+    );
+}


### PR DESCRIPTION
# Fix track texture scrolling for visible enemy units

## Summary

This fixes a long-standing rendering bug inherited from the original Forged Alliance engine.

Tracked units belonging to the current Focus Army display normal scrolling track textures.
A directly visible enemy tracked unit moves normally, but its track texture remains static.
Changing the Focus Army changes which side receives the correct animation.

## Root cause

Visible enemy units use the `ReconBlip` snapshot path. The real source Unit already contains
the four updated texture-scroll values, but the Entity snapshot built for the ReconBlip does
not receive them. Position, orientation, mesh, and movement continue to update while the
track texture uses static scroll values.

## Implementation

At `Moho::ReconBlip::BuildSnapshot + 0x1C1` (`0x005BF171`), the patch redirects the original
six-byte `sub esi, 0xD8` instruction to a section function.

The section function:

1. replays the replaced instruction;
2. preserves EAX, ECX, and the EFLAGS produced by the original instruction;
3. resolves the source Unit reference stored at `ReconBlip + 0x270`;
4. copies the four existing scroll values into the corresponding ReconBlip Entity snapshot fields;
5. resumes at `0x005BF177`.

Field mapping:

```text
Unit + 0x100  -> Recon Entity snapshot + 0x88
Unit + 0x104  -> Recon Entity snapshot + 0x8C
Unit + 0x108  -> Recon Entity snapshot + 0x90
Unit + 0x10C  -> Recon Entity snapshot + 0x94
```

The Unit's Entity subobject begins at `Unit + 0x08`, so the source fields correspond to
`Entity + 0xF8`, `+0xFC`, `+0x100`, and `+0x104`.

## Runtime impact

The patch adds four 32-bit reads and four 32-bit writes for a ReconBlip snapshot with a valid
source Unit. It adds no heap allocation, thread, unit registry, periodic scan, imported
function, or persistent runtime state.

## Validation

A proof-of-concept patch based on FAF 3836 was tested successfully:

- the game loaded into a match and ran normally;
- directly visible enemy tank tracks scrolled correctly;
- Focus Army track animation remained correct;
- changing Focus Army no longer transferred the defect to the other side;
- DXVK and ReShade remained functional in the tested environment.

## Review note

The tested bridge executes whenever this ReconBlip snapshot path has a valid source Unit
reference. Please confirm during review whether this path is already restricted to the fully
visible unit representation. If radar-only or remembered contacts also use it, the copy can
be guarded by the existing full-visibility condition.

## Checklist

- [x] Clear patch and function names
- [x] Original overwritten bytes are replayed
- [x] Registers, stack, and EFLAGS are preserved
- [x] No executable binary is included
- [x] Changelog entry included
- [x] Reproduction and regression test instructions included
- [x] Proof-of-concept tested in game
- [ ] Repository CI build and maintainer review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed track texture scrolling for visible enemy tracked units.
  * Added a changelog entry documenting the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->