### PR TITLE
Fix tracked-unit tread scrolling precision, side mapping, and intermittent stalls

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -70,6 +70,13 @@ These don't matter except for other assembly patches
 
 ## Bugs
 
+- Fix tracked-unit tread scrolling precision, left/right channel mapping, and intermittent zero-delta stalls.
+
+  - hooks/TreadScrollPhaseSideFix.cpp
+  - hooks/TreadScrollZeroGapBridge.cpp
+  - section/TreadScrollPhaseSideFix.cpp
+  - section/TreadScrollZeroGapBridge.cpp
+
 - Remove lingering transport load factor calcuation at aircraft initialization
 
   - hooks/RemoveTransportLoadFactor.cpp

--- a/hooks/TreadScrollPhaseSideFix.cpp
+++ b/hooks/TreadScrollPhaseSideFix.cpp
@@ -1,0 +1,14 @@
+#include "../define.h"
+
+// Keep the deterministic phase rebase separate from the complete WorldMesh
+// copy-block hook. TreadScrollZeroGapBridge owns all four mapped output stores,
+// so there is only one writer for the left/right previous/current pairs.
+asm(
+    ".section h0; .set h0,0x008B9033;"
+    "JMP " QU(TreadScrollPhaseRebase) ";"
+    "NOP;"
+    "NOP;"
+    "NOP;"
+    "NOP;"
+    "NOP;"
+);

--- a/hooks/TreadScrollZeroGapBridge.cpp
+++ b/hooks/TreadScrollZeroGapBridge.cpp
@@ -1,0 +1,8 @@
+#include "../define.h"
+
+// Replaces the straight-line UserEntity -> WorldMesh tread copy block at
+// 0x008B9284 and resumes after it at 0x008B92C4.
+asm(
+    ".section h5; .set h5,0x008B9284;"
+    "JMP " QU(TreadScrollZeroGapBridge) ";"
+);

--- a/section/TreadScrollPhaseSideFix.cpp
+++ b/section/TreadScrollPhaseSideFix.cpp
@@ -1,0 +1,91 @@
+// Keep the two UV scroll phases in a small exact range while preserving the
+// complete signed delta of each channel:
+//
+//   q = trunc(current / 16)
+//   previous -= q * 16
+//   current  -= q * 16
+//
+// The UV layout repeats every 16 phase units. Rebasing previous and current by
+// the same integer multiple therefore leaves direction, speed and interpolation
+// unchanged, while avoiding float precision loss during long sessions.
+
+// GCC emits these file-scope constants in reverse declaration order with the
+// repository build flags. Keep this declaration order so the linked layout is
+// inverse period first, period second, matching the validated v3.1 build.
+extern "C" const float TreadScrollPhasePeriod
+    __asm__("TreadScrollPhasePeriod") = 16.0f;
+extern "C" const float TreadScrollPhaseInversePeriod
+    __asm__("TreadScrollPhaseInversePeriod") = 0.0625f;
+
+extern "C" __attribute__((naked)) void TreadScrollPhaseRebase()
+{
+    asm volatile(
+        // Preserve the pre-hook EFLAGS, MXCSR and XMM0/XMM1 while the
+        // injected arithmetic runs. The replayed CALL's caller-clobbered
+        // EAX/ECX/EDX/EFLAGS/XMM results are dead at 0x008B903D: each is
+        // overwritten before any caller-side read (see the liveness audit).
+        "PUSHFD;"
+        "SUB ESP,0x24;"
+        "MOVUPS [ESP],XMM0;"
+        "MOVUPS [ESP+0x10],XMM1;"
+        "STMXCSR [ESP+0x20];"
+
+        // Replay the original instructions.
+        "LEA EBX,[EDI+0x50];"
+        "MOV EAX,ESI;"
+        "CALL 0x0067A3E0;"
+
+        // Channel A: previous +0xD0, current +0xD8.
+        "MOV ECX,[EDI+0xD8];"
+        "MOV EDX,ECX;"
+        "AND EDX,0x7F800000;"
+        "CMP EDX,0x7F800000;"
+        "JE TreadScrollPhaseRebase_ChannelB;"
+        "MOVD XMM0,ECX;"
+        "MULSS XMM0,DWORD PTR [TreadScrollPhaseInversePeriod];"
+        "CVTTSS2SI ECX,XMM0;"
+        "TEST ECX,ECX;"
+        "JE TreadScrollPhaseRebase_ChannelB;"
+        "CVTSI2SS XMM1,ECX;"
+        "MULSS XMM1,DWORD PTR [TreadScrollPhasePeriod];"
+        "MOVSS XMM0,DWORD PTR [EDI+0xD8];"
+        "SUBSS XMM0,XMM1;"
+        "MOVSS DWORD PTR [EDI+0xD8],XMM0;"
+        "MOVSS XMM0,DWORD PTR [EDI+0xD0];"
+        "SUBSS XMM0,XMM1;"
+        "MOVSS DWORD PTR [EDI+0xD0],XMM0;"
+
+        // Channel B: previous +0xD4, current +0xDC.
+        "TreadScrollPhaseRebase_ChannelB:;"
+        "MOV ECX,[EDI+0xDC];"
+        "MOV EDX,ECX;"
+        "AND EDX,0x7F800000;"
+        "CMP EDX,0x7F800000;"
+        "JE TreadScrollPhaseRebase_Done;"
+        "MOVD XMM0,ECX;"
+        "MULSS XMM0,DWORD PTR [TreadScrollPhaseInversePeriod];"
+        "CVTTSS2SI ECX,XMM0;"
+        "TEST ECX,ECX;"
+        "JE TreadScrollPhaseRebase_Done;"
+        "CVTSI2SS XMM1,ECX;"
+        "MULSS XMM1,DWORD PTR [TreadScrollPhasePeriod];"
+        "MOVSS XMM0,DWORD PTR [EDI+0xDC];"
+        "SUBSS XMM0,XMM1;"
+        "MOVSS DWORD PTR [EDI+0xDC],XMM0;"
+        "MOVSS XMM0,DWORD PTR [EDI+0xD4];"
+        "SUBSS XMM0,XMM1;"
+        "MOVSS DWORD PTR [EDI+0xD4],XMM0;"
+
+        "TreadScrollPhaseRebase_Done:;"
+        "LDMXCSR [ESP+0x20];"
+        "MOVUPS XMM0,[ESP];"
+        "MOVUPS XMM1,[ESP+0x10];"
+        "ADD ESP,0x24;"
+        "POPFD;"
+
+        // The original callee returns EAX = EBX. Other caller-clobbered
+        // return values are dead at the resume point.
+        "MOV EAX,EBX;"
+        "JMP 0x008B903D;"
+    );
+}

--- a/section/TreadScrollZeroGapBridge.cpp
+++ b/section/TreadScrollZeroGapBridge.cpp
@@ -1,0 +1,425 @@
+// Stateful part of the tracked-unit tread-scroll fix. The phase rebase remains
+// in TreadScrollPhaseSideFix.cpp; this file owns the complete mapped WorldMesh
+// copy block and the bounded zero-gap fallback.
+//
+// Observed engine defect:
+//   after confirmed movement, both source tread deltas can become exactly zero
+//   for several simulation updates even though the unit continues moving. The
+//   render path remains active and faithfully displays the zero source deltas.
+//
+// Policy:
+//   - require the same WorldMesh and UserEntity pointers;
+//   - require finite source deltas;
+//   - require source phase continuity and two confirmed moving updates;
+//   - bridge only simultaneous exact-zero deltas;
+//   - reuse the last signed left/right deltas for at most six updates;
+//   - on contention, collision uncertainty, invalid input or discontinuity,
+//     immediately use the native mapped copy;
+//   - preserve a bounded constant phase offset after recovery so native signed
+//     deltas, direction and differential speed remain unchanged.
+//
+// Known review boundary:
+//   a real instantaneous stop from meaningful speed is indistinguishable from
+//   the observed source defect using these four source values alone. It can
+//   therefore visually continue for at most six simulation updates. This
+//   bounded visual trade-off was tested in game, judged minor, and remains
+//   explicitly documented for maintainer review.
+
+extern "C" const float TreadScrollPhaseInversePeriod
+    __asm__("TreadScrollPhaseInversePeriod");
+extern "C" const float TreadScrollPhasePeriod
+    __asm__("TreadScrollPhasePeriod");
+
+// 8192 direct-mapped 32-byte slots, fixed at build time (256 KiB).
+// Layout per slot:
+//   +0x00 WorldMesh key
+//   +0x04 UserEntity key
+//   +0x08 last mapped-left delta
+//   +0x0C last mapped-right delta
+//   +0x10 last source-left current bits  (UserEntity + 0xDC)
+//   +0x14 last source-right current bits (UserEntity + 0xD8)
+//   +0x18 flags and low-byte zero-gap count
+//   +0x1C atomic slot lock
+extern "C" {
+volatile unsigned char TreadScrollZeroGapState[0x40000]
+    __asm__("TreadScrollZeroGapState") __attribute__((aligned(32))) = {};
+}
+
+extern "C" __attribute__((naked)) void TreadScrollRebaseOne()
+    __asm__("TreadScrollRebaseOne");
+extern "C" __attribute__((naked)) void TreadScrollRebaseOne()
+{
+    asm volatile(
+        // Input/output: XMM0. Scratch: EAX, EBX, XMM2.
+        "MOVD EAX,XMM0;"
+        "MOV EBX,EAX;"
+        "AND EBX,0x7F800000;"
+        "CMP EBX,0x7F800000;"
+        "JE TreadScrollRebaseOne_Done;"
+        "MOVAPS XMM2,XMM0;"
+        "MULSS XMM2,DWORD PTR [TreadScrollPhaseInversePeriod];"
+        "CVTTSS2SI EBX,XMM2;"
+        "TEST EBX,EBX;"
+        "JE TreadScrollRebaseOne_Done;"
+        "CVTSI2SS XMM2,EBX;"
+        "MULSS XMM2,DWORD PTR [TreadScrollPhasePeriod];"
+        "SUBSS XMM0,XMM2;"
+        "TreadScrollRebaseOne_Done:;"
+        "RET;"
+    );
+}
+
+extern "C" __attribute__((naked)) void TreadScrollRebaseOutputPairs()
+    __asm__("TreadScrollRebaseOutputPairs");
+extern "C" __attribute__((naked)) void TreadScrollRebaseOutputPairs()
+{
+    asm volatile(
+        // Inputs:
+        //   EBP = WorldMesh
+        //   EDX = locked state slot
+        //   EDI = non-zero when phase continuity was confirmed
+        //   XMM4 = mapped-left source delta
+        // Preserves each previous/current difference exactly.
+        "TEST EDI,EDI;"
+        "JE TreadScrollRebaseOutputPairs_SaveDelta;"
+
+        "MOV EAX,[EBP+0x9C];"
+        "MOV EBX,EAX;"
+        "AND EBX,0x7F800000;"
+        "CMP EBX,0x7F800000;"
+        "JE TreadScrollRebaseOutputPairs_Right;"
+        "MOVD XMM0,EAX;"
+        "MULSS XMM0,DWORD PTR [TreadScrollPhaseInversePeriod];"
+        "CVTTSS2SI EAX,XMM0;"
+        "TEST EAX,EAX;"
+        "JE TreadScrollRebaseOutputPairs_Right;"
+        "CVTSI2SS XMM1,EAX;"
+        "MULSS XMM1,DWORD PTR [TreadScrollPhasePeriod];"
+        "MOVSS XMM0,DWORD PTR [EBP+0x94];"
+        "SUBSS XMM0,XMM1;"
+        "MOVSS DWORD PTR [EBP+0x94],XMM0;"
+        "MOVSS XMM0,DWORD PTR [EBP+0x9C];"
+        "SUBSS XMM0,XMM1;"
+        "MOVSS DWORD PTR [EBP+0x9C],XMM0;"
+
+        "TreadScrollRebaseOutputPairs_Right:;"
+        "MOV EAX,[EBP+0xA0];"
+        "MOV EBX,EAX;"
+        "AND EBX,0x7F800000;"
+        "CMP EBX,0x7F800000;"
+        "JE TreadScrollRebaseOutputPairs_SaveDelta;"
+        "MOVD XMM0,EAX;"
+        "MULSS XMM0,DWORD PTR [TreadScrollPhaseInversePeriod];"
+        "CVTTSS2SI EAX,XMM0;"
+        "TEST EAX,EAX;"
+        "JE TreadScrollRebaseOutputPairs_SaveDelta;"
+        "CVTSI2SS XMM1,EAX;"
+        "MULSS XMM1,DWORD PTR [TreadScrollPhasePeriod];"
+        "MOVSS XMM0,DWORD PTR [EBP+0x98];"
+        "SUBSS XMM0,XMM1;"
+        "MOVSS DWORD PTR [EBP+0x98],XMM0;"
+        "MOVSS XMM0,DWORD PTR [EBP+0xA0];"
+        "SUBSS XMM0,XMM1;"
+        "MOVSS DWORD PTR [EBP+0xA0],XMM0;"
+
+        "TreadScrollRebaseOutputPairs_SaveDelta:;"
+        "MOVSS DWORD PTR [EDX+0x08],XMM4;"
+        "RET;"
+    );
+}
+
+extern "C" __attribute__((naked)) void TreadScrollZeroGapBridge()
+    __asm__("TreadScrollZeroGapBridge");
+extern "C" __attribute__((naked)) void TreadScrollZeroGapBridge()
+{
+    asm volatile(
+        // Original hook context:
+        //   EDI = UserEntity
+        //   EAX = WorldMesh ([EDI + 0x2C])
+        // Original MOVSS block does not modify EFLAGS or general registers.
+        "PUSHFD;"
+        "PUSHAD;"
+        "SUB ESP,0x50;"
+        "MOVDQU [ESP],XMM4;"
+        "MOVDQU [ESP+0x10],XMM5;"
+        "MOVDQU [ESP+0x20],XMM6;"
+        "MOVDQU [ESP+0x30],XMM7;"
+        "STMXCSR [ESP+0x40];"
+
+        "MOV EBP,EAX;"
+        "MOV ESI,EDI;"
+
+        // Mapped left = source channel B; mapped right = source channel A.
+        "MOVSS XMM4,DWORD PTR [ESI+0xDC];"
+        "SUBSS XMM4,DWORD PTR [ESI+0xD4];"
+        "MOVSS XMM5,DWORD PTR [ESI+0xD8];"
+        "SUBSS XMM5,DWORD PTR [ESI+0xD0];"
+
+        // Hash both object pointers to an aligned 32-byte slot.
+        "MOV EDX,EBP;"
+        "XOR EDX,ESI;"
+        "MOV EBX,EDX;"
+        "SHR EDX,7;"
+        "SHR EBX,19;"
+        "XOR EDX,EBX;"
+        "AND EDX,0x1FFF;"
+        "SHL EDX,5;"
+        "LEA EDX,[EDX+TreadScrollZeroGapState];"
+
+        // Non-blocking slot ownership. Busy slots use the native path.
+        "LOCK BTS DWORD PTR [EDX+0x1C],0;"
+        "JC TreadScrollZeroGapBridge_NativeBusy;"
+
+        "CMP [EDX+0x00],EBP;"
+        "JNE TreadScrollZeroGapBridge_InitSlot;"
+        "CMP [EDX+0x04],ESI;"
+        "JNE TreadScrollZeroGapBridge_InitSlot;"
+
+        // Branch to the zero-gap path only when both current deltas are exactly
+        // +0.0 or -0.0.
+        "MOVD EAX,XMM4;"
+        "AND EAX,0x7FFFFFFF;"
+        "JNE TreadScrollZeroGapBridge_NonZero;"
+        "MOVD EAX,XMM5;"
+        "AND EAX,0x7FFFFFFF;"
+        "JNE TreadScrollZeroGapBridge_NonZero;"
+        "JMP TreadScrollZeroGapBridge_Zero;"
+
+        "TreadScrollZeroGapBridge_InitSlot:;"
+        "MOV [EDX+0x00],EBP;"
+        "MOV [EDX+0x04],ESI;"
+        "MOVSS DWORD PTR [EDX+0x08],XMM4;"
+        "MOVSS DWORD PTR [EDX+0x0C],XMM5;"
+        "MOV EAX,[ESI+0xDC];"
+        "MOV [EDX+0x10],EAX;"
+        "MOV EAX,[ESI+0xD8];"
+        "MOV [EDX+0x14],EAX;"
+        "MOV DWORD PTR [EDX+0x18],0;"
+        "JMP TreadScrollZeroGapBridge_NativeLocked;"
+
+        "TreadScrollZeroGapBridge_NonZero:;"
+        // Reject NaN and infinity in either source delta.
+        "MOVD EAX,XMM4;"
+        "MOV EBX,EAX;"
+        "AND EBX,0x7F800000;"
+        "CMP EBX,0x7F800000;"
+        "JE TreadScrollZeroGapBridge_ResetNative;"
+        "MOVD EAX,XMM5;"
+        "MOV EBX,EAX;"
+        "AND EBX,0x7F800000;"
+        "CMP EBX,0x7F800000;"
+        "JE TreadScrollZeroGapBridge_ResetNative;"
+
+        // Exact source continuity: current previous values must equal the last
+        // recorded current values for both channels.
+        "XOR ECX,ECX;"
+        "MOV EAX,[ESI+0xD4];"
+        "CMP EAX,[EDX+0x10];"
+        "JNE TreadScrollZeroGapBridge_ContinuityDone;"
+        "MOV EAX,[ESI+0xD0];"
+        "CMP EAX,[EDX+0x14];"
+        "JNE TreadScrollZeroGapBridge_ContinuityDone;"
+        "MOV ECX,1;"
+        "TreadScrollZeroGapBridge_ContinuityDone:;"
+
+        "MOV EAX,[EDX+0x18];"
+        "MOV EDI,EAX;"
+        "AND EDI,0xA0000000;"
+        "TEST EDI,EDI;"
+        "JE TreadScrollZeroGapBridge_CopyNativeMapped;"
+
+        // Recover from a bridged phase by applying the same constant offset to
+        // previous and current on each side. Native signed deltas are unchanged.
+        "MOVSS XMM6,DWORD PTR [EBP+0x9C];"
+        "SUBSS XMM6,DWORD PTR [ESI+0xD4];"
+        "MOVSS XMM0,DWORD PTR [ESI+0xD4];"
+        "ADDSS XMM0,XMM6;"
+        "MOVSS XMM1,DWORD PTR [ESI+0xDC];"
+        "ADDSS XMM1,XMM6;"
+        "MOVSS DWORD PTR [EBP+0x94],XMM0;"
+        "MOVSS DWORD PTR [EBP+0x9C],XMM1;"
+
+        "MOVSS XMM7,DWORD PTR [EBP+0xA0];"
+        "SUBSS XMM7,DWORD PTR [ESI+0xD0];"
+        "MOVSS XMM0,DWORD PTR [ESI+0xD0];"
+        "ADDSS XMM0,XMM7;"
+        "MOVSS XMM1,DWORD PTR [ESI+0xD8];"
+        "ADDSS XMM1,XMM7;"
+        "MOVSS DWORD PTR [EBP+0x98],XMM0;"
+        "MOVSS DWORD PTR [EBP+0xA0],XMM1;"
+        "JMP TreadScrollZeroGapBridge_AfterMappedCopy;"
+
+        "TreadScrollZeroGapBridge_CopyNativeMapped:;"
+        "MOVSS XMM0,DWORD PTR [ESI+0xD8];"
+        "MOVSS XMM1,DWORD PTR [ESI+0xDC];"
+        "MOVSS XMM2,DWORD PTR [ESI+0xD0];"
+        "MOVSS XMM3,DWORD PTR [ESI+0xD4];"
+        "MOVSS DWORD PTR [EBP+0x94],XMM3;"
+        "MOVSS DWORD PTR [EBP+0x98],XMM2;"
+        "MOVSS DWORD PTR [EBP+0x9C],XMM1;"
+        "MOVSS DWORD PTR [EBP+0xA0],XMM0;"
+
+        "TreadScrollZeroGapBridge_AfterMappedCopy:;"
+        "CALL TreadScrollRebaseOutputPairs;"
+        "MOVSS DWORD PTR [EDX+0x0C],XMM5;"
+        "MOV EAX,[ESI+0xDC];"
+        "MOV [EDX+0x10],EAX;"
+        "MOV EAX,[ESI+0xD8];"
+        "MOV [EDX+0x14],EAX;"
+
+        // Flags: 0x40000000 = continuous update; 0x20000000 = offset mode.
+        "XOR EAX,EAX;"
+        "TEST ECX,ECX;"
+        "JE TreadScrollZeroGapBridge_SaveNonZeroFlags;"
+        "OR EAX,0x40000000;"
+        "TEST EDI,EDI;"
+        "JE TreadScrollZeroGapBridge_SaveNonZeroFlags;"
+        "OR EAX,0x20000000;"
+        "TreadScrollZeroGapBridge_SaveNonZeroFlags:;"
+        "MOV [EDX+0x18],EAX;"
+        "JMP TreadScrollZeroGapBridge_UnlockExit;"
+
+        "TreadScrollZeroGapBridge_Zero:;"
+        "MOV EAX,[EDX+0x18];"
+        "TEST EAX,0x40000000;"
+        "JNE TreadScrollZeroGapBridge_CheckZeroContinuity;"
+        "TEST EAX,0x80000000;"
+        "JE TreadScrollZeroGapBridge_StopZero;"
+
+        "TreadScrollZeroGapBridge_CheckZeroContinuity:;"
+        "MOV EBX,[ESI+0xDC];"
+        "CMP EBX,[EDX+0x10];"
+        "JNE TreadScrollZeroGapBridge_StopZero;"
+        "MOV EBX,[ESI+0xD8];"
+        "CMP EBX,[EDX+0x14];"
+        "JNE TreadScrollZeroGapBridge_StopZero;"
+
+        // Last deltas must be finite and at least 0.01 in magnitude on one side.
+        "MOV EAX,[EDX+0x08];"
+        "MOV EBX,EAX;"
+        "AND EBX,0x7F800000;"
+        "CMP EBX,0x7F800000;"
+        "JE TreadScrollZeroGapBridge_StopZero;"
+        "AND EAX,0x7FFFFFFF;"
+        "MOV ECX,[EDX+0x0C];"
+        "MOV EBX,ECX;"
+        "AND EBX,0x7F800000;"
+        "CMP EBX,0x7F800000;"
+        "JE TreadScrollZeroGapBridge_StopZero;"
+        "AND ECX,0x7FFFFFFF;"
+        "CMP EAX,ECX;"
+        "CMOVB EAX,ECX;"
+        "CMP EAX,0x3C23D70A;"
+        "JB TreadScrollZeroGapBridge_StopZero;"
+
+        // Maximum six bridged zero updates.
+        "MOV EAX,[EDX+0x18];"
+        "AND EAX,0xFF;"
+        "CMP EAX,6;"
+        "JAE TreadScrollZeroGapBridge_ZeroLimit;"
+        "INC EAX;"
+        "OR EAX,0xE0000000;"
+        "MOV [EDX+0x18],EAX;"
+        "MOVSS XMM4,DWORD PTR [EDX+0x08];"
+        "MOVSS XMM5,DWORD PTR [EDX+0x0C];"
+
+        "MOVSS XMM0,DWORD PTR [EBP+0x9C];"
+        "CALL TreadScrollRebaseOne;"
+        "MOVAPS XMM6,XMM0;"
+        "MOVSS XMM0,DWORD PTR [EBP+0xA0];"
+        "CALL TreadScrollRebaseOne;"
+        "MOVAPS XMM7,XMM0;"
+        "MOVSS DWORD PTR [EBP+0x94],XMM6;"
+        "MOVSS DWORD PTR [EBP+0x98],XMM7;"
+        "ADDSS XMM6,XMM4;"
+        "ADDSS XMM7,XMM5;"
+        "MOVSS DWORD PTR [EBP+0x9C],XMM6;"
+        "MOVSS DWORD PTR [EBP+0xA0],XMM7;"
+        "JMP TreadScrollZeroGapBridge_UnlockExit;"
+
+        "TreadScrollZeroGapBridge_ZeroLimit:;"
+        "MOV DWORD PTR [EDX+0x18],0xE0000006;"
+        "MOVSS XMM0,DWORD PTR [EBP+0x9C];"
+        "CALL TreadScrollRebaseOne;"
+        "MOVAPS XMM6,XMM0;"
+        "MOVSS XMM0,DWORD PTR [EBP+0xA0];"
+        "CALL TreadScrollRebaseOne;"
+        "MOVAPS XMM7,XMM0;"
+        "MOVSS DWORD PTR [EBP+0x94],XMM6;"
+        "MOVSS DWORD PTR [EBP+0x98],XMM7;"
+        "MOVSS DWORD PTR [EBP+0x9C],XMM6;"
+        "MOVSS DWORD PTR [EBP+0xA0],XMM7;"
+        "JMP TreadScrollZeroGapBridge_UnlockExit;"
+
+        "TreadScrollZeroGapBridge_StopZero:;"
+        "MOV EAX,[EDX+0x18];"
+        "TEST EAX,0x20000000;"
+        "JE TreadScrollZeroGapBridge_StopZeroNative;"
+        "MOV DWORD PTR [EDX+0x18],0x20000000;"
+        "MOV DWORD PTR [EDX+0x08],0;"
+        "MOV DWORD PTR [EDX+0x0C],0;"
+        "MOVSS XMM0,DWORD PTR [EBP+0x9C];"
+        "CALL TreadScrollRebaseOne;"
+        "MOVAPS XMM6,XMM0;"
+        "MOVSS XMM0,DWORD PTR [EBP+0xA0];"
+        "CALL TreadScrollRebaseOne;"
+        "MOVAPS XMM7,XMM0;"
+        "MOVSS DWORD PTR [EBP+0x94],XMM6;"
+        "MOVSS DWORD PTR [EBP+0x98],XMM7;"
+        "MOVSS DWORD PTR [EBP+0x9C],XMM6;"
+        "MOVSS DWORD PTR [EBP+0xA0],XMM7;"
+        "JMP TreadScrollZeroGapBridge_UnlockExit;"
+
+        "TreadScrollZeroGapBridge_StopZeroNative:;"
+        "MOV DWORD PTR [EDX+0x18],0;"
+        "MOV DWORD PTR [EDX+0x08],0;"
+        "MOV DWORD PTR [EDX+0x0C],0;"
+        "JMP TreadScrollZeroGapBridge_NativeLocked;"
+
+        "TreadScrollZeroGapBridge_ResetNative:;"
+        "MOV DWORD PTR [EDX+0x18],0;"
+        "MOV DWORD PTR [EDX+0x08],0;"
+        "MOV DWORD PTR [EDX+0x0C],0;"
+
+        "TreadScrollZeroGapBridge_NativeLocked:;"
+        "MOVSS XMM0,DWORD PTR [ESI+0xD8];"
+        "MOVSS XMM1,DWORD PTR [ESI+0xDC];"
+        "MOVSS XMM2,DWORD PTR [ESI+0xD0];"
+        "MOVSS XMM3,DWORD PTR [ESI+0xD4];"
+        "MOVSS DWORD PTR [EBP+0x94],XMM3;"
+        "MOVSS DWORD PTR [EBP+0x98],XMM2;"
+        "MOVSS DWORD PTR [EBP+0x9C],XMM1;"
+        "MOVSS DWORD PTR [EBP+0xA0],XMM0;"
+        "JMP TreadScrollZeroGapBridge_UnlockExit;"
+
+        "TreadScrollZeroGapBridge_NativeBusy:;"
+        "MOVSS XMM0,DWORD PTR [ESI+0xD8];"
+        "MOVSS XMM1,DWORD PTR [ESI+0xDC];"
+        "MOVSS XMM2,DWORD PTR [ESI+0xD0];"
+        "MOVSS XMM3,DWORD PTR [ESI+0xD4];"
+        "MOVSS DWORD PTR [EBP+0x94],XMM3;"
+        "MOVSS DWORD PTR [EBP+0x98],XMM2;"
+        "MOVSS DWORD PTR [EBP+0x9C],XMM1;"
+        "MOVSS DWORD PTR [EBP+0xA0],XMM0;"
+        "JMP TreadScrollZeroGapBridge_Exit;"
+
+        "TreadScrollZeroGapBridge_UnlockExit:;"
+        "MOV DWORD PTR [EDX+0x1C],0;"
+
+        "TreadScrollZeroGapBridge_Exit:;"
+        // Restore the XMM0-XMM3 values produced by the original MOVSS loads.
+        "MOVSS XMM0,DWORD PTR [ESI+0xD8];"
+        "MOVSS XMM1,DWORD PTR [ESI+0xDC];"
+        "MOVSS XMM2,DWORD PTR [ESI+0xD0];"
+        "MOVSS XMM3,DWORD PTR [ESI+0xD4];"
+        "LDMXCSR [ESP+0x40];"
+        "MOVDQU XMM4,[ESP];"
+        "MOVDQU XMM5,[ESP+0x10];"
+        "MOVDQU XMM6,[ESP+0x20];"
+        "MOVDQU XMM7,[ESP+0x30];"
+        "ADD ESP,0x50;"
+        "POPAD;"
+        "POPFD;"
+        "JMP 0x008B92C4;"
+    );
+}


### PR DESCRIPTION
## The memo

### Summary

This PR fixes three related defects in the normal tracked-unit
`UserEntity -> WorldMesh` tread-scroll publication path:

1. long-running tread phases can grow large enough to lose useful
   single-precision resolution;
2. the complete physical left/right previous/current channel pairs are assigned
   to the opposite texture-scroll slots;
3. during otherwise steady movement, both source deltas can intermittently
   become exactly zero for several simulation updates, causing a visible
   0.2–0.6 second tread-animation stall.

The changes are submitted together because the final zero-gap hook replaces the
complete four-field copy block and is the single writer that applies the
corrected left/right mapping on every native, bridge, recovery, collision, and
contention path. Splitting the final implementation would require reviewing an
intermediate set of store hooks that the follow-up change immediately removes.

This PR is independent of #159. That PR only forwards existing scroll fields
through the visible-enemy `ReconBlip` snapshot path.

---

## Problems and reproduction

### 1. Long-running phase precision

The engine accumulates tread-scroll phases in single-precision floats. After
enough texture cycles, the absolute phase becomes large while the meaningful
per-update delta remains small.

#### Reproduction

1. Spawn a tracked unit whose tread texture is easy to observe.
2. Keep it moving continuously through many UV cycles; a high simulation speed
   shortens the test.
3. Keep the camera close to the treads.
4. Observe for intermittent visual instability during long movement.

#### Actual

The tread texture can briefly stall, appear to reverse, or show unstable speed
while the chassis continues moving normally.

#### Expected

The signed previous/current delta should remain visually stable regardless of
the accumulated absolute phase.

---

### 2. Left/right channel-pair mapping

The engine produces two complete previous/current tread channels, but the
original four `WorldMesh` stores assign the physical right pair to the first
texture slot and the physical left pair to the second.

#### Reproduction

1. Spawn a normal two-sided tracked unit.
2. Order a left turn, right turn, and rotate-in-place.
3. Compare the inside and outside tread texture speeds.

#### Actual

During differential steering, the inside/outside visual speed relation is
reversed: the inside tread can appear faster than the outside tread.

#### Expected

The outside tread should visually travel faster during a normal turn, while
reverse and rotate-in-place preserve their correct signed directions.

---

### 3. Intermittent simultaneous zero-delta gaps

This defect can reproduce on an empty map with one tracked unit and no AI.

#### Reproduction

1. Start an empty sandbox map with no AI.
2. Spawn one tracked unit with clearly visible treads.
3. Keep it moving steadily in a straight line and visible in the camera.
4. Observe for at least 30–60 seconds.

#### Actual

The tread texture can become completely static for roughly 0.2–0.6 seconds
while the chassis continues moving.

#### Expected

Steady chassis movement should continue publishing a non-zero signed tread delta.

---

## Telemetry-confirmed root cause of the intermittent stall

A diagnostic build first identified the real tread interpolation path and then
captured both source publication and final `WorldMesh` output.

Primary capture:

- 664 valid publication records;
- 25,168 exact target output records;
- 3,512,446 total entries through the real interpolation path;
- maximum exact-target path gap: `0.0466109 s`;
- interpolation-formula mismatches: `0`;
- left/right mapping mismatches: `0`.

During the visible stall:

- the real render path continued executing;
- the interpolation factor continued changing;
- the final output correctly followed the source values;
- both source signed deltas became exactly zero for consecutive simulation
  updates;
- the longest observed defective sequence lasted six publication updates;
- it produced a `0.593144 s` final-output plateau;
- movement resumed with approximately the same signed deltas as before the gap.

A later normal stop was preceded by gradual deceleration to about `0.000671`
phase units per update, rather than an abrupt meaningful-speed-to-zero sequence.

These measurements show that the visible stall is source-side. It is not caused
by a render-path pause or by an incorrect interpolation formula.

---

## Implementation

### Phase rebase

At `0x008B9033`, the hook replays:

```asm
lea ebx, [edi + 0x50]
mov eax, esi
call 0x0067A3E0
```

It then independently rebases both source channels:

```text
q = trunc(current / 16)
previous -= q * 16
current  -= q * 16
```

The tread UV layout repeats every 16 phase units. Subtracting the same integer
multiple from both values preserves:

- signed delta;
- direction;
- speed;
- interpolation fraction;
- differential steering.

NaN and infinity are left unchanged.

### Complete mapped copy block

At `0x008B9284`, the patch replaces the original straight-line four-field
`UserEntity -> WorldMesh` copy block and resumes at `0x008B92C4`.

Every exit path writes the corrected complete channel pairs:

```text
WorldMesh + 0x94 <- mapped left previous  (UserEntity + 0xD4)
WorldMesh + 0x98 <- mapped right previous (UserEntity + 0xD0)
WorldMesh + 0x9C <- mapped left current   (UserEntity + 0xDC)
WorldMesh + 0xA0 <- mapped right current  (UserEntity + 0xD8)
```

No movement speed is inferred, multiplied, or reconstructed.

### Bounded zero-gap state

- 8192 direct-mapped entries;
- 32 bytes per entry;
- fixed BSS size: 256 KiB;
- key: both `WorldMesh` and `UserEntity` pointers;
- non-blocking atomic per-slot lock.

A busy slot immediately uses the native corrected copy. It does not wait and
does not read or clear another thread's state.

A key collision reinitializes the slot for the new pointer pair and never
inherits the old object's speed.

### Bridge policy

A gap is bridged only when all of the following hold:

1. both current source deltas are exactly `+0.0` or `-0.0`;
2. saved signed deltas are finite;
3. current source previous values exactly equal the last source current values;
4. at least two continuous non-zero updates previously confirmed movement;
5. at least one saved side has magnitude `>= 0.01`;
6. fewer than six zero updates have already been bridged.

The previous signed left/right deltas are reused for at most six updates.

When native non-zero values return, the real source values are used again with a
constant per-side phase offset applied equally to previous and current. The
native signed delta, direction, and differential speed therefore remain
unchanged. Output pairs are synchronously rebased by integer multiples of the
16-unit period so the output phase remains bounded.

Native corrected output is used immediately for invalid input, source
discontinuity, insufficient confirmed movement, low-speed stops, one-side-zero
steering, key initialization, bridge-limit expiration, and lock contention.

---

## Behavior after the fix

- Long-running source and output phases remain bounded.
- Native non-zero signed deltas are preserved.
- Forward and reverse retain native speed and sign.
- Differential steering uses the correct physical left/right channels.
- Rotate-in-place retains opposite signed tread directions.
- The telemetry-observed six-update high-speed zero gap is bridged.
- Hash collisions do not transfer speed between units.
- Lock contention does not block the simulation thread.
- A bridge stops after the sixth zero update; the seventh zero update is static.

---

## Known bounded visual behavior

A true transition from meaningful speed to an exact instantaneous stop has the
same four source-field signature as the observed defect. In that case the tread
texture may continue at the previous signed speed for at most six simulation
updates, approximately 0.6 seconds.

This case was specifically tested in game. The continuation was brief, did not
persist, and its visual impact was judged minor and acceptable.

Gradual deceleration, low-speed stopping, one-side-zero steering, reverse, and
normal differential turning do not satisfy the complete bridge policy.

---

## Runtime and memory impact

- fixed BSS: 262,144 bytes;
- direct-mapped O(1) lookup;
- no dynamic allocation;
- no new thread;
- no periodic scan;
- no imported function or Windows API call;
- no file or registry I/O;
- non-blocking slot ownership;
- busy and uncertain paths immediately use the native corrected output.

The final hook restores the original `XMM0–XMM3` load results, preserved
`XMM4–XMM7`, MXCSR, general registers, EFLAGS, and stack depth before resuming.

---

## Validation performed

### Phase and mapping validation

- source compiled with repository-equivalent 32-bit GCC flags and additional
  `-Wall -Wextra -Werror`;
- linked phase function and constants matched the in-game-tested phase fix;
- 10,000 direct compiled-machine-code phase cases;
- positive and negative phases;
- large magnitudes;
- 16-period boundaries;
- zero, NaN, and infinity;
- no phase-output, stack, saved-register, MXCSR, or XMM mismatch.

### Final machine-code regression

- 100,000 randomized forward, reverse, and differential updates;
- 40,000 rotate-in-place cases;
- 20,000 forced hash collisions;
- lock-busy fallback;
- gradual stopping;
- one-side-zero steering;
- six-update bridge limit and seventh-update stop;
- bridge recovery and long bounded-phase runs.

Observed errors:

- non-zero speed mismatch: `0`;
- direction mismatch: `0`;
- left/right mapping mismatch: `0`;
- cross-unit state mismatch: `0`.

### Real telemetry replay

Both the 664-record and 1108-record publication captures were replayed:

- all observed high-speed zero-gap sequences were bridged;
- non-zero native updates retained their original signed deltas;
- the final normal deceleration and stop remained stopped;
- no mapping mismatch was introduced.

### In-game validation

The final v4.5 test build:

- removed the intermittent tread stall in the test environment;
- did not reproduce the earlier experimental cross-unit direction or speed
  regressions;
- preserved forward, reverse, turning, rotate-in-place, stop, and restart;
- kept long-running phase values bounded;
- showed only the disclosed brief continuation during a deliberately tested
  instantaneous stop.

---

## Regression test instructions

1. Test UEF, Cybran, and Aeon tracked units.
2. Empty map, no AI, one tracked unit: steady movement for at least 60 seconds.
3. Long forward and reverse movement.
4. Left and right turns at several radii.
5. Rotate-in-place.
6. One-side-zero steering.
7. Stop, restart, and direction reversal.
8. Deliberate instantaneous stop; verify any continuation is bounded to at most
   about 0.6 seconds.
9. Spawn many tracked units to exercise hashing and contention fallback.
10. Test camera distance and LOD transitions.
11. With #159 present, change Focus Army and test directly visible enemy units.
12. Compare memory and simulation performance before and after.

---

## Scope

This PR fixes the engine's two global tread-scroll channels.

A model whose rear or auxiliary tread geometry is assigned to the wrong UV band
still requires an SCM/UV asset correction. Another global channel swap would
break geometry that is already correct.

---

## Files changed

```text
hooks/TreadScrollPhaseSideFix.cpp
hooks/TreadScrollZeroGapBridge.cpp
section/TreadScrollPhaseSideFix.cpp
section/TreadScrollZeroGapBridge.cpp
changelog.md
```

## Checklist

- [x] Read the repository contribution guide and engine-patch guide
- [x] Clear patch/function names and fixed-address comments
- [x] Replaced instructions and resume addresses documented
- [x] Hook bytes, registers, stack, EFLAGS, MXCSR, and XMM state audited
- [x] No new public engine structure or reusable engine function requiring
      `moho.h`, `global.h`, or `Info.txt`
- [x] README reviewed; the repository README directs notable changes to
      `changelog.md`, where this PR adds its entry
- [x] Reproduction and regression test instructions included
- [x] Known bounded instantaneous-stop behavior disclosed and tested
- [x] No executable or raw telemetry artifact included
- [x] Source/build/machine-code and in-game validation completed
- [ ] Repository CI/full patcher build and maintainer review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tracked-unit tread scrolling precision, including correct left/right channel mapping.
  - Prevented intermittent zero-delta stalls during tread movement.
  - Improved phase continuity to maintain smoother, more consistent scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->