### PR TITLE
Complete HEAPMNG page-map coverage and high-address coalescing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -155,7 +155,7 @@ These don't matter except for other assembly patches
 
 ## Improvements
 
-- Allows to use 4GB on x64
+- Complete HEAPMNG page-map coverage and enable free-region coalescing across the 3-4 GiB range on x64.
 
   - hooks/HFix4GB.cpp
 

--- a/hooks/HFix4GB.cpp
+++ b/hooks/HFix4GB.cpp
@@ -1,6 +1,8 @@
 asm(
+  // Allocate one 4-byte map entry for every 4 KiB page in the complete
+  // 32-bit virtual address space: 0x100000 entries * 4 = 0x400000 bytes.
   ".section h0; .set h0,0x957E35;"
-  "PUSH 0x3FF000;"
+  "PUSH 0x400000;"
 
   ".section h1; .set h1,0x915A92;"
   "ADD EAX,EAX;"
@@ -11,4 +13,9 @@ asm(
 
   ".section h2; .set h2,0x915B05;"
   "JMP .-0x73;"
+
+  // Keep 0x100000 as the one-past-end page index while allowing free
+  // regions in the 3-4 GiB range to coalesce with a right neighbour.
+  ".section h3; .set h3,0x958107;"
+  "CMP EAX,0x100000;"
 );


### PR DESCRIPTION
## The memo

### Summary

This PR completes the existing `HFix4GB` HEAPMNG bookkeeping across the
full 32-bit page-index range.

It makes two same-size immediate-value changes:

1. allocate `0x400000` bytes for the page map instead of `0x3FF000`;
2. use `0x100000` as the right-neighbour one-past-end page bound instead
   of `0xC0000`.

No function is replaced and no new runtime code path is introduced.

Closes #163.

Related game-level evidence:

- FAForever/fa#7195
- maudlin27/M28AI#394

---

## Allocator limitations

### Incomplete page-map capacity

At `0x00957E35`, the current `HFix4GB` patch emits:

```asm
PUSH 0x3FF000
```

A complete 32-bit address space contains:

```text
2^32 / 2^12 = 0x100000
```

4 KiB page indices.

At four bytes per page-map entry, complete arithmetic capacity is:

```text
0x100000 * 4 = 0x400000 bytes
```

`0x3FF000` provides `0xFFC00` entries and leaves the highest `0x400`
pages, or 4 MiB of virtual-address range, without an entry.

### 3 GiB right-neighbour bound

At `0x00958107`, the allocator computes the page index immediately after
a freed region and compares it with:

```asm
CMP EAX,0xC0000
JAE skip_right_neighbour
```

`0xC0000` pages corresponds to 3 GiB. Therefore a free region whose
right-hand page lies in the 3-4 GiB range cannot query and merge with
that neighbour.

The replacement uses `0x100000`, which is the one-past-end page index
for the full 4 GiB range. The existing `JAE` continues to skip lookup
when the computed page index is outside the map.

---

## Implementation

### `hooks/HFix4GB.cpp`

Page-map allocation:

```asm
# 0x00957E35
PUSH 0x3FF000
->
PUSH 0x400000
```

Right-neighbour guard:

```asm
# 0x00958107
CMP EAX,0xC0000
->
CMP EAX,0x100000
```

Exact instruction bytes:

```text
68 00 F0 3F 00 -> 68 00 00 40 00
3D 00 00 0C 00 -> 3D 00 00 10 00
```

The existing Lua-GC control-flow patches in `HFix4GB.cpp` are unchanged.

### `changelog.md`

The existing 4 GB entry now describes the complete page-map coverage
and 3-4 GiB coalescing behavior.

---

## Safety and runtime impact

- The page map grows by exactly 4 KiB at allocator initialization.
- Both patched instructions retain their original five-byte length.
- The `PUSH` keeps the same stack behavior and changes only the size
  passed to `VirtualAlloc`.
- The `CMP` sets flags exactly as before; only the upper bound changes.
- The existing `JAE` still prevents a lookup at or beyond page index
  `0x100000`.
- No new allocation loop, branch, thread, import, state object, file I/O,
  registry I/O, or periodic work is added.
- There is no per-allocation instruction-count increase.

The original rationale for the smaller constants is not documented.
The full-range arithmetic and boundary behavior are exact, but
maintainer review should still consider whether the old values encoded
an undocumented legacy invariant.

---

## Evidence

An equivalent local executable candidate was produced from the tested
baseline by changing only these two immediates and recalculating the PE
checksum.

Tested baseline:

```text
SHA256 db05b62768fd1cea4cbc2fdce4bbf0778fe85353cd1fc3b1048db330914d08b6
```

Equivalent allocator candidate:

```text
SHA256 22cb537385a402ad2ad1671c5cc63da8a1a29e9af9c91769d6dc0ddc27ac855e
```

The equivalent binary participated in the lowest-growth documented
stress run:

```text
Heap Total / Committed = 1.406 GiB / approximately 1.30-1.33 GiB
```

Heap Total remained at `1.406 GiB` from session time `00:39:07` through
at least `00:48:08`.

A separate run with the paired M28-side cache active reached:

```text
1.930 GiB / approximately 1.24-1.26 GiB
```

The executable identity of that counterexample is not recoverable from
its log. These runs therefore demonstrate that this patch is part of a
successful low-growth configuration, but they do not isolate its
independent contribution.

This PR does not claim that every process path above 2 GiB becomes safe.
Its intended effect is to complete allocator bookkeeping and improve
the opportunity to reuse high-address free regions before the process
enters that range.

---

## Validation performed

### Source and opcode validation

- source is based on repository master commit `96af320e872a083fdb302fde7406d6d7f17c418d`;
- original `HFix4GB.cpp` content was checked against that commit;
- original executable bytes were verified at both virtual addresses;
- replacement opcodes were assembled independently as 32-bit x86;
- both generated instructions are exactly five bytes;
- the patch applies and reverses cleanly against the checked source
  context;
- `git diff --check` equivalent whitespace checks pass.

### Binary reconstruction

A verifier applied the two instruction replacements to the tested
baseline, recalculated the PE checksum, and reproduced the known
candidate byte-for-byte:

```text
reconstructed SHA256:
22cb537385a402ad2ad1671c5cc63da8a1a29e9af9c91769d6dc0ddc27ac855e

byte-for-byte candidate match:
PASS
```

The reconstructed output differs from the baseline only at:

- three immediate-value bytes;
- three PE-checksum bytes.

The PE entry point, image base, section table, Large Address Aware flag,
and all unrelated patch bytes remain unchanged.

### Boundary and stress model

- full map entries: `0x100000`;
- old map entries: `0xFFC00`;
- missing old range: `0x400` pages / 4 MiB;
- final valid page index: `0xFFFFF`;
- one-past-end index: `0x100000`;
- deterministic 2,000,000-region model: all valid regions fit the new
  map and high-address cases that exceed the old map are detected.

### Runtime evidence

The equivalent local binary has been used in real FAF games. The
documented low-growth run is linked through `fa#7195`.

The repository patcher and repository CI were not executable in the
current environment; those checks remain for CI and maintainer review.

---

## Regression test instructions

1. Build the patched executable from the repository.
2. Verify the output bytes:
   - `0x00957E35`: `68 00 00 40 00`;
   - `0x00958107`: `3D 00 00 10 00`.
3. Start a vanilla sandbox and verify normal allocation, unit creation,
   save, load, and shutdown.
4. Run a long vanilla AI game and compare Heap Total / Committed with the
   current build.
5. Run the stress workload from `fa#7195`.
6. Repeat the four cells below at least three times each:

| Cell | HEAPMNG patch | M28 same-tick cache |
|---|---:|---:|
| A | Off | Off |
| B | On | Off |
| C | Off | On |
| D | On | On |

7. Instrument or inspect:
   - `VirtualAlloc` growth reservations;
   - page-map write start/end around `0x0095854F`;
   - largest reusable free region before growth;
   - right-neighbour lookups and merges at page indices `>= 0xC0000`;
   - any out-of-range map access or free-list corruption.
8. Compare simulation correctness and performance before and after.

---

## Files changed

```text
hooks/HFix4GB.cpp
changelog.md
```

## Checklist

- [x] Read the repository contribution and engine-patch guides
- [x] Linked the research issue closed by this PR
- [x] Exact patch addresses, old/new instructions, and bytes documented
- [x] Original instructions verified against the tested executable
- [x] Same-size instruction replacement; no resume-address change
- [x] Stack, EFLAGS, and control-flow effects audited
- [x] No new public structure or reusable engine symbol requiring
      `moho.h`, `global.h`, or `Info.txt`
- [x] Changelog updated
- [x] Test and regression instructions included
- [x] No executable or proprietary game artifact included
- [x] Equivalent binary reconstruction and byte audit completed
- [x] Equivalent local runtime evidence documented
- [ ] Repository patcher build and CI
- [ ] Maintainer review of possible undocumented legacy invariants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded x64 memory management to provide complete page-map coverage across the 32-bit address space.
  * Enabled free-region coalescing throughout the 3–4 GiB memory range.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->