### PR TITLE
Increase particle and segment render-buffer pool capacities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -155,6 +155,10 @@ These don't matter except for other assembly patches
 
 ## Improvements
 
+- Increase the fixed particle render-buffer pool from 400 to 4096 entries and the segment-buffer pool from 100 to 400 entries.
+
+  - hooks/ParticlePoolCapacity.cpp
+    
 - Allows to use 4GB on x64
 
   - hooks/HFix4GB.cpp

--- a/hooks/ParticlePoolCapacity.cpp
+++ b/hooks/ParticlePoolCapacity.cpp
@@ -1,0 +1,12 @@
+asm(
+  // The constructor at 0x4928A0 builds a fixed pool of particle
+  // render-buffer descriptors. Keep each descriptor's native capacity
+  // unchanged and raise only the number of available descriptors.
+  ".section h0; .set h0,0x4928ED;"
+  "MOV DWORD PTR [ESP+0x10],0x1000;"
+
+  // The same constructor builds a separate fixed pool used by segment
+  // buffers. The native per-buffer creation arguments remain unchanged.
+  ".section h1; .set h1,0x4929B2;"
+  "MOV DWORD PTR [ESP+0x10],0x190;"
+);


### PR DESCRIPTION
## The memo

### Summary

This PR raises two fixed render-resource pool counts created by the particle
renderer during initialization:

- particle render-buffer descriptors: `400 -> 4096`;
- segment-buffer descriptors: `100 -> 400`.

It does **not** make the particle system unbounded. The existing pool,
checkout, release, recycling, and exhaustion behavior remains intact; the
engine simply has more descriptors available before reaching the same native
limit path.

No Lua, simulation, synchronization, effect lifetime, or per-buffer capacity
logic is changed.

---

## Problem

The initialization routine at `0x004928A0` creates both pools with fixed loop
counts.

### Particle render-buffer pool

At `0x004928ED`:

```asm
MOV DWORD PTR [ESP+0x10],0x190
```

The loop allocates `0x2C`-byte descriptors and keeps the native per-descriptor
capacity at `0xC8` (`200`).

The original fixed count is therefore:

```text
400 descriptors * 200 entries = 80,000 nominal entries
```

Particle-heavy battles and effect-heavy mods can exhaust the fixed pool. Once
no descriptor is available, the existing engine path cannot provide another
render buffer and additional particle work is omitted until resources return
to the pool.

### Segment-buffer pool

At `0x004929B2`:

```asm
MOV DWORD PTR [ESP+0x10],0x64
```

This is a separate construction loop for `0x18`-byte segment-buffer
descriptors. The existing per-buffer creation argument of `0x190` remains
unchanged.

---

## Implementation

A new fixed-address hook changes only the two loop-count immediates.

### `hooks/ParticlePoolCapacity.cpp`

Particle render-buffer descriptors:

```asm
# VA 0x004928ED
MOV DWORD PTR [ESP+0x10],0x190
->
MOV DWORD PTR [ESP+0x10],0x1000
```

Exact bytes:

```text
C7 44 24 10 90 01 00 00
->
C7 44 24 10 00 10 00 00
```

Segment-buffer descriptors:

```asm
# VA 0x004929B2
MOV DWORD PTR [ESP+0x10],0x64
->
MOV DWORD PTR [ESP+0x10],0x190
```

Exact bytes:

```text
C7 44 24 10 64 00 00 00
->
C7 44 24 10 90 01 00 00
```

Both instructions remain eight bytes long. The decrement-and-branch loops,
allocation sizes, list insertion, resource release, resource recycling, and
pool-exhaustion guards are unchanged.

### Resulting fixed capacities

```text
Particle render-buffer descriptors: 400 -> 4096  (10.24x)
Nominal particle entries:            80,000 -> 819,200
Segment-buffer descriptors:          100 -> 400   (4x)
```

---

## Memory and performance impact

The initialization loops allocate descriptor objects of `0x2C` and `0x18`
bytes respectively.

The exact additional descriptor payload is:

```text
(4096 - 400) * 0x2C = 162,624 bytes
(400 - 100)  * 0x18 =   7,200 bytes
------------------------------------
descriptor payload delta = 169,824 bytes (~165.8 KiB)
```

Allocator metadata is not included in that number.

The patch adds no runtime branch, lookup, thread, periodic scan, dynamic table,
or per-particle instruction. Its direct CPU cost is limited to the one-time
initialization of the additional descriptors.

When a workload exceeds the old limits, the intended result is that more
particle work continues to render instead of reaching the old pool ceiling.
That can increase CPU work, GPU work, process memory, and video-memory usage
relative to the old behavior. The system remains bounded by the new fixed pool
sizes and retains the native exhaustion guard.

---

## Validation performed

### Repository and source review

- based on `FAForever/FA-Binary-Patches` master commit `96af320e872a083fdb302fde7406d6d7f17c418d`;
- no existing hook or open Issue/PR matching these two addresses was found;
- the repository engine-patch guide and PR template were reviewed;
- the implementation uses a hook-only source file, matching the repository
  rule that `/hooks` contains assembly patches.

### Instruction and control-flow validation

- original instructions were disassembled in the FAF 3836 baseline;
- both replacement instructions were independently assembled as 32-bit x86;
- replacement lengths remain exactly eight bytes;
- stack destination, loop variable location, decrement, and `JNE` targets are
  unchanged;
- no register or EFLAGS behavior is changed beyond loading the new immediate
  loop count.

### Binary reconstruction

Tested baseline:

```text
size:   12,537,600 bytes
SHA256: a6acf849803f7f38fbaa612b77c910bde239f6b5a4ff8f8786f719e2aec0f09d
```

Known local particle-pool candidate:

```text
size:   12,537,600 bytes
SHA256: 58a610668653295d3274db66b346a9d93e25f93b65d9331df35d203ca4cc4d43
```

Applying only the two immediate replacements to the baseline reproduces the
known candidate byte-for-byte.

The candidate differs from the baseline at exactly four byte positions:

```text
0x000928F1: 90 -> 00
0x000928F2: 01 -> 10
0x000929B6: 64 -> 90
0x000929B7: 00 -> 01
```

The PE entry point, image base, section table, file size, and Large Address
Aware flag remain unchanged.

### Runtime evidence boundary

The same two particle-pool changes were present in later combined user test
executables used for long, heavy FAF games, providing general startup and
long-session smoke coverage.

A controlled before/after particle-saturation capture has not yet been
attached, so this PR does not claim a measured FPS gain or a measured count of
previously omitted effects.

---

## Regression test instructions

1. Build the executable from this branch.
2. Verify the output instructions:
   - `0x004928ED`: `C7 44 24 10 00 10 00 00`;
   - `0x004929B2`: `C7 44 24 10 90 01 00 00`.
3. Start and exit the game repeatedly to exercise pool construction and
   destruction.
4. Run a vanilla sandbox and verify normal weapons, explosions, smoke, build
   effects, reclaim effects, trails, beams, and decals.
5. Replay the same particle-heavy scenario on the current and patched builds.
6. Continue until the current build begins omitting visible effects, then
   compare the patched build at the same time and camera position.
7. Where instrumentation is available, record:
   - active and free particle render-buffer descriptors;
   - active and free segment-buffer descriptors;
   - entries through the native exhaustion/discard path;
   - frame time, FPS, process private bytes, and video-memory use.
8. Test long sessions, save/load, observer mode, camera and LOD transitions,
   and effect-heavy SIM mods.
9. Verify that pool exhaustion remains safe at the new limits and does not read
   from an empty list.
10. Compare shutdown behavior and confirm all resources are still released.

---

## Scope and limitations

- This raises two fixed pool counts; it does not remove all particle limits.
- The per-particle-buffer capacity remains `200`.
- The existing segment-buffer creation size remains `400`.
- No effect blueprint, spawn rate, lifetime, culling rule, or renderer discard
  policy is changed.
- This PR does not claim that every missing visual effect is caused by these
  two pools.
- Controlled saturation telemetry remains the preferred final runtime
  validation.

---

## Files changed

```text
hooks/ParticlePoolCapacity.cpp
changelog.md
```

## Checklist

- [x] Read the repository contribution guide, engine-patch guide, and PR template
- [x] Checked current master and searched for a duplicate particle-pool patch
- [x] Exact addresses, original/replacement instructions, and bytes documented
- [x] Same-size instruction replacements; no resume-address change
- [x] Loop control, stack destination, registers, and EFLAGS audited
- [x] Additional fixed descriptor payload quantified
- [x] No new public engine structure or reusable function requiring
      `moho.h`, `global.h`, or `Info.txt`
- [x] Changelog entry prepared
- [x] Test and regression instructions included
- [x] No executable or proprietary game artifact included
- [x] Equivalent local binary reconstructed byte-for-byte
- [ ] Repository patcher build and CI
- [ ] Controlled particle-saturation A/B capture
- [ ] Maintainer review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the available particle render-buffer capacity from 400 to 4,096 entries.
  * Increased the segment-buffer capacity from 100 to 400 entries.
  * Helps support larger particle effects and reduce capacity-related limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->